### PR TITLE
Build shared pcntl module

### DIFF
--- a/templates/php_blueprint.sh.erb
+++ b/templates/php_blueprint.sh.erb
@@ -89,7 +89,8 @@ function build_php() {
       --enable-mbregex \
       --enable-exif=shared \
       --with-openssl=shared \
-      --enable-fpm
+      --enable-fpm \
+      --enable-pcntl=shared
   else
     cd "php-$PHP_VERSION"
   fi


### PR DESCRIPTION
This builds ``pcntl`` as a shared module.

As far as I could tell the module ends up in the php tarball as intended.

Due to the fact that ``pcntl`` has been part of php for ages I do not suspect this to be any different in the various php versions supported by the php buildpack.

The ``pcntl`` module has been requested in both cloudfoundry/php-buildpack#82 and cloudfoundry/php-buildpack#78.