### PR TITLE
Build shared readline

### DIFF
--- a/templates/php_blueprint.sh.erb
+++ b/templates/php_blueprint.sh.erb
@@ -90,7 +90,8 @@ function build_php() {
       --enable-exif=shared \
       --with-openssl=shared \
       --enable-fpm \
-      --enable-pcntl=shared
+      --enable-pcntl=shared \
+      --with-readline=shared
   else
     cd "php-$PHP_VERSION"
   fi


### PR DESCRIPTION
I'm trying to do a proof of concept drupal 8 install the [composer way](https://www.drupal.org/node/2471553) from [this repo](https://github.com/drupal-composer/drupal-project) and am finding it requires ``ext-readline``.

Personally, I want to use it so i can run database setup routines for my cloudy drupal instance by pushing a ``--no-route`` instance that connects to the same service I'll use on the routed instance.

I could also see myself executing things like drupals cron jobs by regularly scheduling such a routeless machine to spin up an instance.

edit: Link to [readline docs on php.net](http://php.net/manual/en/book.readline.php).