### PR TITLE
Build the PHP memcached extension with sasl support.

### DIFF
--- a/helpers/php/install-deps.sh
+++ b/helpers/php/install-deps.sh
@@ -1,7 +1,7 @@
 # update repo and packages
 sudo apt-get update
 sudo apt-get -y upgrade
-sudo apt-get -y install build-essential autoconf automake libssl-dev libsnmp-dev snmp-mibs-downloader mercurial libbz2-dev libldap2-dev libpcre3-dev libxml2-dev libpq-dev libzip-dev libcurl4-openssl-dev libgdbm-dev libmysqlclient-dev libgmp-dev libjpeg-dev libpng12-dev libc-client2007e-dev libsasl2-dev libmcrypt-dev libaspell-dev libpspell-dev libexpat1-dev imagemagick libmagickwand-dev libmagickcore-dev unzip libmemcached-dev libicu-dev libsqlite3-dev libzookeeper-mt-dev libreadline-dev libxslt1-dev libyaml-dev
+sudo apt-get -y install build-essential autoconf automake libssl-dev libsnmp-dev snmp-mibs-downloader mercurial libbz2-dev libldap2-dev libpcre3-dev libxml2-dev libpq-dev libzip-dev libcurl4-openssl-dev libgdbm-dev libmysqlclient-dev libgmp-dev libjpeg-dev libpng12-dev libc-client2007e-dev libsasl2-dev libmcrypt-dev libaspell-dev libpspell-dev libexpat1-dev imagemagick libmagickwand-dev libmagickcore-dev unzip libicu-dev libsqlite3-dev libzookeeper-mt-dev libreadline-dev libxslt1-dev libyaml-dev
 
 # Ubuntu 14.04 puts these headers in weird locations, need to add symlinks so PHP finds them
 sudo ln -fs /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h

--- a/helpers/php/php-common.sh
+++ b/helpers/php/php-common.sh
@@ -8,6 +8,24 @@
 #     Date:  11-17-2013
 #
 ##################################################################
+build_libmemcached() {
+	cd "$BUILD_DIR"
+	if [ ! -d "libmemcached-$LIBMEMCACHED_VERSION" ]; then
+		curl -L -O "https://launchpad.net/libmemcached/1.0/$LIBMEMCACHED_VERSION/+download/libmemcached-$LIBMEMCACHED_VERSION.tar.gz"
+                tar zxf "libmemcached-$LIBMEMCACHED_VERSION.tar.gz"
+                rm "libmemcached-$LIBMEMCACHED_VERSION.tar.gz"
+		cd "libmemcached-$LIBMEMCACHED_VERSION"
+		./configure --prefix="$APP_DIR/libmemcached-$LIBMEMCACHED_VERSION"
+		make -j 5
+	else
+		cd "libmemcached-$LIBMEMCACHED_VERSION"
+	fi
+	if [ ! -d "$APP_DIR/libmemcached-$LIBMEMCACHED_VERSION" ]; then
+		make install
+	fi
+	cd "$BUILD_DIR"
+}
+
 build_librabbit() {
 	cd "$BUILD_DIR"
 	if [ ! -d "rabbitmq-c-$RABBITMQ_C_VERSION" ]; then
@@ -229,6 +247,9 @@ build_external_extension() {
         build_ioncube $VERSION
         return # commercial, but redistributable
     fi
+	if [ "$NAME" == "memcached" ]; then
+		build_libmemcached
+	fi
 	if [ "$NAME" == "phalcon" ]; then
 		build_phpalcon $VERSION
 		return # has it's own build script, so we just run it and return
@@ -271,7 +292,8 @@ build_external_extension() {
 			./configure --with-php-config="$APP_DIR/php/bin/php-config" --with-librabbitmq-dir="$APP_DIR/librmq-$RABBITMQ_C_VERSION"
 		elif [ "$NAME" == "memcached" ]; then
 			./configure --with-php-config="$APP_DIR/php/bin/php-config" \
-                --disable-memcached-sasl \
+                --with-libmemcached-dir="$APP_DIR/libmemcached-$LIBMEMCACHED_VERSION" \
+                --enable-memcached-sasl \
 				--enable-memcached-msgpack \
 				--enable-memcached-igbinary \
 				--enable-memcached-json

--- a/lib/architect/php_architect.rb
+++ b/lib/architect/php_architect.rb
@@ -7,18 +7,21 @@ module BinaryBuilder
       '5.4' => {
         ZTS_VERSION:          "20100525",
         RABBITMQ_C_VERSION:   "0.5.2",
+        LIBMEMCACHED_VERSION: "1.0.18",
         HIREDIS_VERSION:      "0.11.0",
         LUA_VERSION:          "5.2.4"
       },
       '5.5' => {
         ZTS_VERSION:          "20121212",
         RABBITMQ_C_VERSION:   "0.5.2",
+        LIBMEMCACHED_VERSION: "1.0.18",
         HIREDIS_VERSION:      "0.11.0",
         LUA_VERSION:          "5.2.4"
       },
       '5.6' => {
         ZTS_VERSION:          "20131226",
         RABBITMQ_C_VERSION:   "0.5.2",
+        LIBMEMCACHED_VERSION: "1.0.18",
         HIREDIS_VERSION:      "0.11.0",
         LUA_VERSION:          "5.2.4"
       }

--- a/templates/php_blueprint.sh.erb
+++ b/templates/php_blueprint.sh.erb
@@ -25,6 +25,7 @@ ZTS_VERSION=<%= external_libraries[:ZTS_VERSION] %>
 
 # Third Party Module Versions
 RABBITMQ_C_VERSION=<%= external_libraries[:RABBITMQ_C_VERSION] %>
+LIBMEMCACHED_VERSION=<%= external_libraries[:LIBMEMCACHED_VERSION] %>
 HIREDIS_VERSION=<%= external_libraries[:HIREDIS_VERSION] %>
 LUA_VERSION=<%= external_libraries[:LUA_VERSION] %>
 
@@ -112,7 +113,7 @@ package_php_extensions() {
 
   package_php_extension "$APP_DIR/librmq-$RABBITMQ_C_VERSION/lib/librabbitmq.so.1"
   package_php_extension "libicui18n.so.52" "libicuuc.so.52" "libicudata.so.52" "libicuio.so.52"
-  package_php_extension "libmemcached.so.10"
+  package_php_extension "$APP_DIR/libmemcached-$LIBMEMCACHED_VERSION/lib/libmemcached.so.11"
   package_php_extension "$APP_DIR/hiredis-$HIREDIS_VERSION/lib/libhiredis.so.0.10"
 
   cd "$APP_DIR"


### PR DESCRIPTION
This is required for talking to most public service providers as they need it authentication.

Changes:

 - don't install libmemcached from Ubuntu, this doesn't seem to support sasl
 - download and install libmemcached from source, this can be configured with sasl support
 - change the extension to compile with sasl support