### PR TITLE
Added an OraclePeclRecipe which builds the oci8 extension from Pecl.

### DIFF
--- a/recipe/php5_meal.rb
+++ b/recipe/php5_meal.rb
@@ -187,6 +187,7 @@ class Php5Meal
     twigpecl_recipe.cook
     xcachepecl_recipe.cook
     xhprofpecl_recipe.cook
+    oracle_recipe.cook unless not oracle_recipe.oracle_sdk?
     memcachedpecl_recipe.cook
   end
 
@@ -208,6 +209,7 @@ class Php5Meal
 
   def setup_tar
     php_recipe.setup_tar
+    oracle_recipe.setup_tar unless not oracle_recipe.oracle_sdk?
   end
 
   private
@@ -225,6 +227,7 @@ class Php5Meal
       twigpecl_recipe.send(:files_hashs) +
       xcachepecl_recipe.send(:files_hashs) +
       xhprofpecl_recipe.send(:files_hashs) +
+      oracle_recipe.send(:files_hashs) +
       libmemcached_recipe.send(:files_hashs) +
       memcachedpecl_recipe.send(:files_hashs) +
       @pecl_recipes.collect { |r| r.send(:files_hashs) }.flatten
@@ -307,5 +310,10 @@ class Php5Meal
   def xhprofpecl_recipe
     @xhprofpecl_recipe ||= XhprofPeclRecipe.new('xhprof', '0bbf2a2ac3', md5: '1df4aebf1cb24e7cf369b3af357106fc',
                                                                         php_path: php_recipe.path)
+  end
+
+  def oracle_recipe
+    @oracle_recipe ||= OraclePeclRecipe.new('oci8', '2.0.11', md5: 'b953aec8600b1990fc1956bd5f580b0b',
+									php_path: php_recipe.path)
   end
 end

--- a/recipe/php7_meal.rb
+++ b/recipe/php7_meal.rb
@@ -164,6 +164,7 @@ class Php7Meal
     standard_pecl('yaf', '3.0.3', '74504e8f0ed7c346804c5a5043a5682b')
     amqppecl_recipe.cook
     luapecl_recipe.cook
+    oracle_recipe.cook unless not oracle_recipe.oracle_sdk?
   end
 
   def url
@@ -184,6 +185,7 @@ class Php7Meal
 
   def setup_tar
     php_recipe.setup_tar
+    oracle_recipe.setup_tar unless not oracle_recipe.oracle_sdk?
   end
 
   private
@@ -193,6 +195,7 @@ class Php7Meal
       lua_recipe.send(:files_hashs) +
       luapecl_recipe.send(:files_hashs) +
       amqppecl_recipe.send(:files_hashs) +
+      oracle_recipe.send(:files_hashs) +
       @pecl_recipes.collect { |r| r.send(:files_hashs) }.flatten
   end
 
@@ -217,5 +220,10 @@ class Php7Meal
     @luapecl_recipe ||= LuaPeclRecipe.new('lua', '2.0.1', md5: '56924db266f3748a0432328e764b7782',
                                                           php_path: php_recipe.path,
                                                           lua_path: lua_recipe.path)
+  end
+
+  def oracle_recipe
+    @oracle_recipe ||= OraclePeclRecipe.new('oci8', '2.1.1', md5: '01bb3429ce3206dcc3d3198e65dadfbc',
+							     php_path: php_recipe.path)
   end
 end

--- a/recipe/php7_meal.rb
+++ b/recipe/php7_meal.rb
@@ -21,7 +21,6 @@ class Php7Recipe < BaseRecipe
       '--with-cdb',
       '--with-gdbm',
       '--with-mcrypt=shared',
-      '--with-mysql=shared',
       '--with-mysqli=shared',
       '--enable-pdo=shared',
       '--with-pdo-sqlite=shared,/usr',

--- a/recipe/php_common.rb
+++ b/recipe/php_common.rb
@@ -110,6 +110,32 @@ class AmqpPeclRecipe < PeclRecipe
   end
 end
 
+class OraclePeclRecipe < PeclRecipe
+  def configure_options
+    [
+      "--with-oci8=shared,instantclient,/oracle"
+    ]
+  end
+
+  def oracle_sdk?
+    File.directory?('/oracle')
+  end
+
+  def setup_tar
+    puts "Copying oracle libs from /oracle/ to #{@php_path}/lib"
+    system <<-eof
+      cp -a /oracle/libclntshcore.so.12.1 #{@php_path}/lib
+      cp -a /oracle/libclntsh.so #{@php_path}/lib
+      cp -a /oracle/libclntsh.so.12.1 #{@php_path}/lib
+      cp -a /oracle/libipc1.so #{@php_path}/lib
+      cp -a /oracle/libmql1.so #{@php_path}/lib
+      cp -a /oracle/libnnz12.so #{@php_path}/lib
+      cp -a /oracle/libociicus.so #{@php_path}/lib
+      cp -a /oracle/libons.so #{@php_path}/lib
+    eof
+  end
+end
+
 class LuaPeclRecipe < PeclRecipe
   def configure_options
     [


### PR DESCRIPTION
This requires Oracle's Instant Client Lite & SDK.  These are not
provided by the PR and need to be supplied by the end user.  If these
are not supplied, the OraclePeclRecipe will be an noop.

Build instructions are the same with one exception, you need to add an
additonal mount instruction to `docker run`, i.e. `-v
/path/to/instant/client&sdk:/oracle`.  The recipe expects the files to
be at `/oracle` and without those files the recipe won't run.

For PHP 5.5 and 5.6, the recipe pulls in oci8 2.0.x.  For PHP 7, it
pulls in 2.1.x.

The recipe pulls in the following Oracle libraries and bundles them with
the resulting PHP binary (in `php/lib`).

 - libclntshcore.so
 - libclntsh.so
 - libipc1.so
 - libmql1.so
 - libnnz12.so
 - libociicus.so
 - libons.so

Please be aware of this and that distributing these files is likely in
violation of Oracles terms and conditions.

Please also be aware that libociicus.so is a US English specific library
from the Instant Client Lite.  If you need multi-language support, you
may need to use the full Instant Client and include additional
libraries.

Let me know if there's anything that needs to be cleaned up here.  Consider this a first draft.

Thanks!