### PR TITLE
Added support to build the `oci8` and `pdo_oci` extensions

### DIFF
--- a/PHP-Oracle.md
+++ b/PHP-Oracle.md
@@ -1,0 +1,55 @@
+# PHP & Oracle Support
+
+The binary builder has support for building the `oci8` and `pdo_oci` extensions of PHP 5.5, 5.6 and 7.0.  While the builder is capable of building them, it does *not* provide the Oracle libraries and SDK which are required to build these extensions.  These are not provided by binary-builder because of licensing restrictions and binary builder does not automatically download them because they are behind an Oracle pay-wall.  To build the extensions, you *must* download and provide these to the builder.
+
+## What to Downwload
+
+The requirements to build these extensions are listed here.
+
+  http://php.net/manual/en/oci8.requirements.php
+
+This basically boils down to installing the Oracle Instant Client Basic or Basic Lite plus the SDK.  Use the ZIP installs and extract them to a location on your local machine.  Then create the following symbolic library before building: `ln -s libclntsh.so.12.1 libclntsh.so` (version number must vary).  
+
+You only need to do this once.
+
+## How to Build
+
+To build, you just [follow the normal instructions for building PHP with binary builder & Docker](https://github.com/dmikusa-pivotal/binary-builder/blob/master/README.md#running-within-docker).  The only exception is that you need to map the path where you extracted the Oracle instant client and SDK to `/oracle` in the docker container used by binary builder.
+
+This is done by adding an additiona `-v` argument to the `docker run` command.
+
+Ex:
+
+```
+docker run -w /binary-builder -v `pwd`:/binary-builder -v /path/to/oracle:/oracle -it cloudfoundry/cflinuxfs2 bash ./bin/binary-builder --name=php7 --version=7.0.9 --md5=32ea3ce54d7d5ed03c6c600dffd65813
+```
+
+## What's Included
+
+When you build PHP binaries with Oracle support you get the following included with the PHP binary:
+
+1. The `oci8` extension (from PECL)
+    - PHP 5.5 & 5.6 include oci8 2.0.x
+    - PHP 7.0 includes oci 2.1.x
+2. The `pdo_oci` extension bundled with PHP
+3. The following libraries which are required by the extensions are include in `php/lib`
+    - libclntshcore.so
+    - libclntsh.so
+    - libipc1.so
+    - libmql1.so
+    - libnnz12.so
+    - libociicus.so
+    - libons.so
+
+Two notes on the included libraries:
+
+1. The file `libociicus.so` is a US English specific library from Instant Client lite.  If you need multi-language support, you will need to install the full Instant Client and likely include additional libraries.  That's not supported at this time, but patches are welcome.
+
+2. The PHP bundle that is built by binary builder has Oracle libraries from the Instant Client packaged with it.  As such, you should not publicly distribute these libraries unless you are licensed to do so by Oracle.
+
+## Disabling Oracle Support
+
+By default Oracle Support is *not* included.  The binary builder will not and cannot build these extensions unless you provide it with the Oracle libraries as listed in the *What to Download* section above.
+
+If you want to build with and without Oracle support, you can control if binary-builder will include the Oracle support by adding or removing the volume map for `/oracle` on your `docker run` command.  If that volume is mounted then binary builder will attempt to build Oracle support.  If it's not mounted, Oracle support is disabled.
+

--- a/recipe/php5_meal.rb
+++ b/recipe/php5_meal.rb
@@ -192,6 +192,8 @@ class Php5Meal
     twigpecl_recipe.cook
     xcachepecl_recipe.cook
     xhprofpecl_recipe.cook
+    oracle_recipe.cook unless not OraclePeclRecipe.oracle_sdk?
+    oracle_pdo_recipe.cook unless not OraclePdoRecipe.oracle_sdk?
     memcachedpecl_recipe.cook
   end
 
@@ -213,6 +215,8 @@ class Php5Meal
 
   def setup_tar
     php_recipe.setup_tar
+    oracle_recipe.setup_tar unless not OraclePeclRecipe.oracle_sdk?
+    oracle_pdo_recipe.setup_tar unless not OraclePdoRecipe.oracle_sdk?
   end
 
   private
@@ -230,6 +234,8 @@ class Php5Meal
       twigpecl_recipe.send(:files_hashs) +
       xcachepecl_recipe.send(:files_hashs) +
       xhprofpecl_recipe.send(:files_hashs) +
+      (OraclePeclRecipe.oracle_sdk? ? oracle_recipe.send(:files_hashs) : []) +
+      (OraclePdoRecipe.oracle_sdk? ? oracle_pdo_recipe.send(:files_hashs) : []) +
       libmemcached_recipe.send(:files_hashs) +
       memcachedpecl_recipe.send(:files_hashs) +
       @pecl_recipes.collect { |r| r.send(:files_hashs) }.flatten
@@ -312,5 +318,16 @@ class Php5Meal
   def xhprofpecl_recipe
     @xhprofpecl_recipe ||= XhprofPeclRecipe.new('xhprof', '0bbf2a2ac3', md5: '1df4aebf1cb24e7cf369b3af357106fc',
                                                                         php_path: php_recipe.path)
+  end
+
+  def oracle_recipe
+    @oracle_recipe ||= OraclePeclRecipe.new('oci8', '2.0.11', md5: 'b953aec8600b1990fc1956bd5f580b0b',
+                                                              php_path: php_recipe.path)
+  end
+
+  def oracle_pdo_recipe
+    @oracle_pdo_recipe ||= OraclePdoRecipe.new('pdo_oci', version,
+                                               php_source: "#{php_recipe.send(:tmp_path)}/php-#{version}",
+                                               php_path: php_recipe.path)
   end
 end

--- a/recipe/php7_meal.rb
+++ b/recipe/php7_meal.rb
@@ -169,6 +169,8 @@ class Php7Meal
     standard_pecl('cassandra', '1.2.1', 'dca2cda61a1ff6a6cecb94f88a75c757')
     amqppecl_recipe.cook
     luapecl_recipe.cook
+    oracle_recipe.cook unless not OraclePeclRecipe.oracle_sdk?
+    oracle_pdo_recipe.cook unless not OraclePdoRecipe.oracle_sdk?
   end
 
   def url
@@ -189,6 +191,8 @@ class Php7Meal
 
   def setup_tar
     php_recipe.setup_tar
+    oracle_recipe.setup_tar unless not OraclePeclRecipe.oracle_sdk?
+    oracle_pdo_recipe.setup_tar unless not OraclePdoRecipe.oracle_sdk?
   end
 
   private
@@ -198,6 +202,8 @@ class Php7Meal
       lua_recipe.send(:files_hashs) +
       luapecl_recipe.send(:files_hashs) +
       amqppecl_recipe.send(:files_hashs) +
+      (OraclePeclRecipe.oracle_sdk? ? oracle_recipe.send(:files_hashs) : []) +
+      (OraclePdoRecipe.oracle_sdk? ? oracle_pdo_recipe.send(:files_hashs) : []) +
       @pecl_recipes.collect { |r| r.send(:files_hashs) }.flatten
   end
 
@@ -222,5 +228,16 @@ class Php7Meal
     @luapecl_recipe ||= LuaPeclRecipe.new('lua', '2.0.1', md5: '56924db266f3748a0432328e764b7782',
                                                           php_path: php_recipe.path,
                                                           lua_path: lua_recipe.path)
+  end
+
+  def oracle_recipe
+    @oracle_recipe ||= OraclePeclRecipe.new('oci8', '2.1.1', md5: '01bb3429ce3206dcc3d3198e65dadfbc',
+							     php_path: php_recipe.path)
+  end
+
+  def oracle_pdo_recipe
+    @oracle_pdo_recipe ||= OraclePdoRecipe.new('pdo_oci', version,
+                                               php_source: "#{php_recipe.send(:tmp_path)}/php-#{version}",
+                                               php_path: php_recipe.path)
   end
 end

--- a/recipe/php_common.rb
+++ b/recipe/php_common.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require_relative 'base'
+require 'uri'
 
 class RabbitMQRecipe < BaseRecipe
   def url
@@ -107,6 +108,77 @@ class AmqpPeclRecipe < PeclRecipe
       "--with-php-config=#{@php_path}/bin/php-config",
       "--with-librabbitmq-dir=#{@rabbitmq_path}"
     ]
+  end
+end
+
+class OraclePeclRecipe < PeclRecipe
+  def configure_options
+    [
+      "--with-oci8=shared,instantclient,/oracle"
+    ]
+  end
+
+  def self.oracle_sdk?
+    File.directory?('/oracle')
+  end
+
+  def setup_tar
+    system <<-eof
+      cp -an /oracle/libclntshcore.so.12.1 #{@php_path}/lib
+      cp -an /oracle/libclntsh.so #{@php_path}/lib
+      cp -an /oracle/libclntsh.so.12.1 #{@php_path}/lib
+      cp -an /oracle/libipc1.so #{@php_path}/lib
+      cp -an /oracle/libmql1.so #{@php_path}/lib
+      cp -an /oracle/libnnz12.so #{@php_path}/lib
+      cp -an /oracle/libociicus.so #{@php_path}/lib
+      cp -an /oracle/libons.so #{@php_path}/lib
+    eof
+  end
+end
+
+class OraclePdoRecipe < PeclRecipe
+  def url
+    "file://#{@php_source}/ext/pdo_oci-#{version}.tar.gz"
+  end
+
+  def download
+    # this copys an extension folder out of the PHP source director (i.e. `ext/<name>`)
+    # it pretends to download it by making a zip of the extension files
+    # that way the rest of the PeclRecipe works normally
+    files_hashs.each do |file|
+      path = URI(file[:url]).path.rpartition('-')[0] # only need path before the `-`, see url above
+      system <<-eof
+        echo 'tar czf "#{file[:local_path]}" -C "#{File.dirname(path)}" "#{File.basename(path)}"'
+        tar czf "#{file[:local_path]}" -C "#{File.dirname(path)}" "#{File.basename(path)}"
+      eof
+    end
+  end
+
+  def configure_options
+    [
+      "--with-pdo-oci=shared,instantclient,/oracle,#{OraclePdoRecipe.oracle_version}"
+    ]
+  end
+
+  def self.oracle_sdk?
+    File.directory?('/oracle')
+  end
+
+  def self.oracle_version
+    Dir["/oracle/*"].select {|i| i.match(/libclntsh\.so\./) }.map {|i| i.sub(/.*libclntsh\.so\./, '')}.first
+  end
+
+  def setup_tar
+    system <<-eof
+      cp -an /oracle/libclntshcore.so.12.1 #{@php_path}/lib
+      cp -an /oracle/libclntsh.so #{@php_path}/lib
+      cp -an /oracle/libclntsh.so.12.1 #{@php_path}/lib
+      cp -an /oracle/libipc1.so #{@php_path}/lib
+      cp -an /oracle/libmql1.so #{@php_path}/lib
+      cp -an /oracle/libnnz12.so #{@php_path}/lib
+      cp -an /oracle/libociicus.so #{@php_path}/lib
+      cp -an /oracle/libons.so #{@php_path}/lib
+    eof
   end
 end
 


### PR DESCRIPTION
Added support to build the `oci8` and `pdo_oci` extensions for PHP 5.5, 5.6 and 7.0.  These are conditionally built based on the presence of the Oracle Instant Client & SDK.  Additional documentation and instructions are included in the PHP-Oracle.md file.

Test suite ran with no errors with and without the Oracle libraries present.

Let me know if there's any feedback on the code.  My first time using mini_portile.

Thanks!