### PR TITLE
Removed the compile flag for the old mysql extension.

### DIFF
--- a/recipe/php7_meal.rb
+++ b/recipe/php7_meal.rb
@@ -21,7 +21,6 @@ class Php7Recipe < BaseRecipe
       '--with-cdb',
       '--with-gdbm',
       '--with-mcrypt=shared',
-      '--with-mysql=shared',
       '--with-mysqli=shared',
       '--enable-pdo=shared',
       '--with-pdo-sqlite=shared,/usr',


### PR DESCRIPTION
  This option was removed in PHP7.  This just cleans up a warning when `./configure` runs.