### PR TITLE
support a rubygem mirror

### DIFF
--- a/bin/binary-builder
+++ b/bin/binary-builder
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
 gem install bundler --no-rdoc --no-ri
+bundle config mirror.https://rubygems.org ${RUBYGEM_MIRROR}
 bundle install
 bundle exec ./bin/binary-builder.rb "$@"


### PR DESCRIPTION
set RUBYGEM_MIRROR as environment variable, to use a mirror to access rubygem