### PR TITLE
Geoip extension

### DIFF
--- a/PHP-Geoip.md
+++ b/PHP-Geoip.md
@@ -1,0 +1,17 @@
+# PHP & GeoIP Support
+
+The binary builder has support for building the `geoip` extension for PHP 5.5, 5.6 and 7.0.  In order for the `geoip` extension to function properly though it requires a database of geoip data.  The company MaxMind provides both commercial and less accurate open source versions of these databases.
+
+In the default mode, binary-builder will not bundle any database files with PHP, however it will bundle a script that can be run to download an up-to-date version of the open source (also called "lite") databases.
+
+If you would like binary-builder to download the open source version of the databases and bundle them with PHP, it can do that too.  To instruct binary-builder to do that, create a file called `BUNDLE_GEOIP_LITE` in the top level of the project and set the contents of the file to `true`.  When binary-builder sees that this file exists and that the contents are `true` it will download and bundle the open source version of the databases with the resulting PHP binary.
+
+Right now binary-builder can't be configured to download and bundle commercial versions of the geoip data from MaxMind.  You can download commercial versions via the included script (see below), but there is no option exposed to configure the script through binary-builder.
+
+## What's Included
+
+When you build PHP binaries with GeoIP support you get the following included with the PHP binary:
+
+1. The `geoip` extension (from PECL)
+2. The library file `geoipdb/lib/geoip_downloader.rb` and script `geoipdb/bin/download_geoip_db.rb` which can be run at a later date to download a copy of the geoip databases from MaxMind.  By default they will download the "lite" or open source versions but the script can be configured to use a user id & license key to download paid versions as well.
+3. If bundled, the geoip databases will be under `geoipdb/dbs`.  If not bundled, that directory will be empty.  If bundled, the following databases will be included:  GeoLiteCityv6.dat, GeoLiteASNum.dat, GeoLiteCountry.dat, GeoIPv6.dat and GeoLiteCity.dat.

--- a/bin/download_geoip_db.rb
+++ b/bin/download_geoip_db.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+# encoding: utf-8
+
+require "net/http"
+require "uri"
+require "digest"
+require "tempfile"
+require "optparse"
+require_relative "../lib/geoip_downloader"
+
+options = {}
+optparser = OptionParser.new do |opts|
+    opts.banner = 'USAGE: download_geoip_db [options]'
+
+    opts.on('-uUSER', '--user=USER', 'User Id from MaxMind.  Default "999999".') do |n|
+        options[:user] = n
+    end
+
+    opts.on('-lLICENSE', '--license=LICENSE', 'License from MaxMind.  Default "000000000000".') do |n|
+        options[:license] = n
+    end
+
+    opts.on('-oOUTPUTDIR', '--output_dir=OUTPUTDIR', 'Directory where databases might exist and will be written / updated.  Default "."') do |n|
+        options[:output_dir] = n
+    end
+
+    opts.on('-pPRODUCTS', '--products=PRODUCTS', 'Space separated list of product ids.  Default "GeoLite-Legacy-IPv6-City GeoLite-Legacy-IPv6-Country 506 517 533".') do |n|
+        options[:products] = n
+    end
+end
+optparser.parse!
+
+options[:user] ||= '999999'
+options[:license] ||= '000000000000'
+options[:output_dir] ||= '.'
+options[:products] ||= "GeoLite-Legacy-IPv6-City GeoLite-Legacy-IPv6-Country 506 517 533"
+
+updater = MaxMindGeoIpUpdater.new(options[:user], options[:license], options[:output_dir])
+options[:products].split(" ").each do |product|
+    updater.download_product(product)
+end

--- a/lib/geoip_downloader.rb
+++ b/lib/geoip_downloader.rb
@@ -1,0 +1,96 @@
+# encoding: utf-8
+require "net/http"
+require "uri"
+require "digest"
+require "tempfile"
+
+class MaxMindGeoIpUpdater
+    def initialize(user_id, license, output_dir)
+        @proto = 'http'
+        @host = 'updates.maxmind.com'
+        @user_id = user_id
+        @license = license
+        @output_dir = output_dir
+        @client_ip = nil
+        @challenge_digest = nil
+    end
+    
+    def get_filename(product_id)
+        uri = URI.parse("#{@proto}://#{@host}/app/update_getfilename")
+        uri.query = URI.encode_www_form({ :product_id => product_id})
+        resp = Net::HTTP.get_response(uri)
+        resp.body
+    end
+
+    def client_ip
+        @client_ip ||= begin
+            uri = URI.parse("#{@proto}://#{@host}/app/update_getipaddr")
+            resp = Net::HTTP.get_response(uri)
+            resp.body
+        end
+    end
+
+    def download_database(db_digest, challenge_digest, product_id, file_path)
+        uri = URI.parse("#{@proto}://#{@host}/app/update_secure")
+        uri.query = URI.encode_www_form({
+            :db_md5 => db_digest,
+            :challenge_md5 => challenge_digest,
+            :user_id => @user_id,
+            :edition_id => product_id
+        })
+        Net::HTTP.start(uri.host, uri.port) do |http|
+            req = Net::HTTP::Get.new(uri)
+            
+            http.request(req) do |resp|
+                file = Tempfile.new('geiop_db_download')
+                begin
+                    if resp['content-type'] == 'text/plain; charset=utf-8'
+                        puts "\talready up-to-date."
+                    else
+                        resp.read_body do |chunk|
+                            file.write(chunk)
+                        end
+                        file.rewind
+                        extract_file(file, file_path)
+                        puts "\tdatabase updated."
+                    end
+                ensure
+                    file.close()
+                    file.unlink()
+                end
+            end
+        end
+    end
+
+    def extract_file(file, file_path)
+        gz = Zlib::GzipReader.new(file)
+        begin
+            File.open(file_path, 'w') do |out|
+                IO.copy_stream(gz, out)
+            end
+        ensure
+            gz.close
+        end
+    end
+
+    def download_product(product_id)
+        puts "Downloading..."
+        file_name = get_filename(product_id)
+        file_path = File.join(@output_dir, file_name)
+        db_digest = db_digest(file_path)
+        puts "\tproduct_id: #{product_id}"
+        puts "\tfile_name: #{file_name}"
+        puts "\tip: #{client_ip}"
+        puts "\tdb: #{db_digest}"
+        puts "\tchallenge: #{challenge_digest}"
+        download_database(db_digest, challenge_digest, product_id, file_path)
+    end
+
+    def db_digest(path)
+        return File::exist?(path) ? Digest::MD5.file(path) : '00000000000000000000000000000000'
+    end
+
+    def challenge_digest
+        return Digest::MD5.hexdigest("#{@license}#{client_ip}")
+    end
+end

--- a/recipe/php5_recipe.rb
+++ b/recipe/php5_recipe.rb
@@ -101,6 +101,7 @@ class Php5Recipe < BaseRecipe
       cp -a /usr/local/lib/x86_64-linux-gnu/librabbitmq.so* #{path}/lib/
       cp -a /usr/lib/x86_64-linux-gnu/libsybdb.so* #{path}/lib/
       cp -a /usr/lib/librdkafka.so* #{path}/lib
+      cp -a /usr/lib/x86_64-linux-gnu/libGeoIP.so* #{path}/lib/
 
       # Remove unused files
       rm "#{path}/etc/php-fpm.conf.default"

--- a/recipe/php7_recipe.rb
+++ b/recipe/php7_recipe.rb
@@ -94,6 +94,7 @@ class Php7Recipe < BaseRecipe
       cp -a /usr/local/lib/x86_64-linux-gnu/libcassandra.so* #{path}/lib
       cp -a /usr/lib/x86_64-linux-gnu/libuv.so* #{path}/lib
       cp -a /usr/lib/librdkafka.so* #{path}/lib
+      cp -a /usr/lib/x86_64-linux-gnu/libGeoIP.so* #{path}/lib/
     eof
 
     if IonCubeRecipe.build_ioncube?(version)

--- a/recipe/php_meal.rb
+++ b/recipe/php_meal.rb
@@ -158,7 +158,8 @@ class PhpMeal
       libxml2-dev
       libzip-dev
       libzookeeper-mt-dev
-      snmp-mibs-downloader)
+      snmp-mibs-downloader
+      libgeoip-dev)
   end
 
   def symlink_commands

--- a/spec/integration/php5_with_geolitedb_spec.rb
+++ b/spec/integration/php5_with_geolitedb_spec.rb
@@ -3,13 +3,13 @@ require 'spec_helper'
 require 'fileutils'
 require 'open-uri'
 
-describe 'building a binary', :integration do
-  context 'when php5 is specified' do
+describe 'building a binary', :run_geolite_php_tests do
+  context 'when php5 is specified with geolite databases' do
     before(:all) do
       @extensions_dir = Dir.mktmpdir(nil, './spec')
       extensions_file = File.join(@extensions_dir, 'php-extensions.yml')
       extensions_url  = 'https://raw.githubusercontent.com/cloudfoundry/public-buildpacks-ci-robots/master/binary-builds/php-extensions.yml'
-
+      
       File.write(extensions_file, open(extensions_url).read)
       run_binary_builder('php', '5.6.14', "--md5=ae625e0cfcfdacea3e7a70a075e47155 --php-extensions-file=#{extensions_file}")
       @binary_tarball_location = Dir.glob(File.join(Dir.pwd, 'php-5.6.14-linux-x64.tgz')).first
@@ -20,18 +20,10 @@ describe 'building a binary', :integration do
       FileUtils.rm_rf(@extensions_dir)
     end
 
-    it 'builds the specified binary, tars it, and places it in your current working directory' do
-      expect(File).to exist(@binary_tarball_location)
-
-      php_version_cmd = %{./spec/assets/php-exerciser.sh 5.6.14 #{File.basename(@binary_tarball_location)} ./php/bin/php -r 'echo phpversion();'}
-
-      output, status = run(php_version_cmd)
-
-      expect(status).to be_success
-      expect(output).to include('5.6.14')
-    end
-
     it 'copies in *.so files for some of the compiled extensions' do
+      file_to_enable_geolite_db = File.join(Dir.pwd, 'BUNDLE_GEOIP_LITE')
+      expect(File.exist? file_to_enable_geolite_db).to eq true
+
       expect(tar_contains_file('php/lib/librabbitmq.so.4')).to eq true
       expect(tar_contains_file('php/lib/libhiredis.so.0.13')).to eq true
       expect(tar_contains_file('php/lib/libc-client.so.2007e')).to eq true
@@ -55,6 +47,12 @@ describe 'building a binary', :integration do
       expect(tar_contains_file('php/lib/php/extensions/*/geoip.so')).to eq true
       expect(tar_contains_file('php/geoipdb/lib/geoip_downloader.rb')).to eq true
       expect(tar_contains_file('php/geoipdb/bin/download_geoip_db.rb')).to eq true
+
+      expect(tar_contains_file('php/geoipdb/dbs/GeoLiteCityv6.dat')).to eq true
+      expect(tar_contains_file('php/geoipdb/dbs/GeoLiteASNum.dat')).to eq true
+      expect(tar_contains_file('php/geoipdb/dbs/GeoLiteCountry.dat')).to eq true
+      expect(tar_contains_file('php/geoipdb/dbs/GeoIPv6.dat')).to eq true
+      expect(tar_contains_file('php/geoipdb/dbs/GeoLiteCity.dat')).to eq true
     end
   end
 end

--- a/spec/integration/php71_spec.rb
+++ b/spec/integration/php71_spec.rb
@@ -50,6 +50,11 @@ describe 'building a binary', :integration do
       # phalcon does not support php 7.1.x yet
       # https://github.com/phalcon/cphalcon/issues/12444
       expect(tar_contains_file('php/lib/php/extensions/*/phalcon.so')).to eq false
+
+      expect(tar_contains_file('php/lib/libGeoIP.so.1')).to eq true
+      expect(tar_contains_file('php/lib/php/extensions/*/geoip.so')).to eq true
+      expect(tar_contains_file('php/geoipdb/lib/geoip_downloader.rb')).to eq true
+      expect(tar_contains_file('php/geoipdb/bin/download_geoip_db.rb')).to eq true
     end
   end
 end

--- a/spec/integration/php7_spec.rb
+++ b/spec/integration/php7_spec.rb
@@ -46,6 +46,11 @@ describe 'building a binary', :integration do
       expect(tar_contains_file('php/lib/php/extensions/*/ioncube.so')).to eq true
       expect(tar_contains_file('php/lib/php/extensions/*/phpiredis.so')).to eq true
       expect(tar_contains_file('php/lib/php/extensions/*/phalcon.so')).to eq true
+
+      expect(tar_contains_file('php/lib/libGeoIP.so.1')).to eq true
+      expect(tar_contains_file('php/lib/php/extensions/*/geoip.so')).to eq true
+      expect(tar_contains_file('php/geoipdb/lib/geoip_downloader.rb')).to eq true
+      expect(tar_contains_file('php/geoipdb/bin/download_geoip_db.rb')).to eq true
     end
   end
 end

--- a/spec/integration/php7_with_geolitedb_spec.rb
+++ b/spec/integration/php7_with_geolitedb_spec.rb
@@ -3,16 +3,16 @@ require 'spec_helper'
 require 'fileutils'
 require 'open-uri'
 
-describe 'building a binary', :integration do
-  context 'when php5 is specified' do
+describe 'building a binary', :run_geolite_php_tests do
+  context 'when php7.0 is specified with geolite databases' do
     before(:all) do
       @extensions_dir = Dir.mktmpdir(nil, './spec')
-      extensions_file = File.join(@extensions_dir, 'php-extensions.yml')
-      extensions_url  = 'https://raw.githubusercontent.com/cloudfoundry/public-buildpacks-ci-robots/master/binary-builds/php-extensions.yml'
+      extensions_file = File.join(@extensions_dir, 'php7-extensions.yml')
+      extensions_url  = 'https://raw.githubusercontent.com/cloudfoundry/public-buildpacks-ci-robots/master/binary-builds/php7-extensions.yml'
 
       File.write(extensions_file, open(extensions_url).read)
-      run_binary_builder('php', '5.6.14', "--md5=ae625e0cfcfdacea3e7a70a075e47155 --php-extensions-file=#{extensions_file}")
-      @binary_tarball_location = Dir.glob(File.join(Dir.pwd, 'php-5.6.14-linux-x64.tgz')).first
+      run_binary_builder('php7', '7.0.3', "--md5=235b1217a9ec7bee6e0bd517e3636d45 --php-extensions-file=#{extensions_file}")
+      @binary_tarball_location = Dir.glob(File.join(Dir.pwd, 'php7-7.0.3-linux-x64.tgz')).first
     end
 
     after(:all) do
@@ -20,41 +20,36 @@ describe 'building a binary', :integration do
       FileUtils.rm_rf(@extensions_dir)
     end
 
-    it 'builds the specified binary, tars it, and places it in your current working directory' do
-      expect(File).to exist(@binary_tarball_location)
-
-      php_version_cmd = %{./spec/assets/php-exerciser.sh 5.6.14 #{File.basename(@binary_tarball_location)} ./php/bin/php -r 'echo phpversion();'}
-
-      output, status = run(php_version_cmd)
-
-      expect(status).to be_success
-      expect(output).to include('5.6.14')
+    it 'has created the BUNDLE_GEOIP_LITE file' do
+        file_to_enable_geolite_db = File.join(Dir.pwd, 'BUNDLE_GEOIP_LITE')
+        expect(File.exist? file_to_enable_geolite_db).to eq true
     end
 
     it 'copies in *.so files for some of the compiled extensions' do
       expect(tar_contains_file('php/lib/librabbitmq.so.4')).to eq true
-      expect(tar_contains_file('php/lib/libhiredis.so.0.13')).to eq true
       expect(tar_contains_file('php/lib/libc-client.so.2007e')).to eq true
+      expect(tar_contains_file('php/lib/libhiredis.so.0.13')).to eq true
       expect(tar_contains_file('php/lib/libmcrypt.so.4')).to eq true
-      expect(tar_contains_file('php/lib/libaspell.so.15')).to eq true
       expect(tar_contains_file('php/lib/libpspell.so.15')).to eq true
-      expect(tar_contains_file('php/lib/libmemcached.so.11')).to eq true
-      expect(tar_contains_file('php/lib/libgearman.so.7')).to eq true
+      expect(tar_contains_file('php/lib/libmemcached.so.10')).to eq true
       expect(tar_contains_file('php/lib/libcassandra.so.2')).to eq true
       expect(tar_contains_file('php/lib/libuv.so.0.10')).to eq true
-      expect(tar_contains_file('php/lib/libsybdb.so.5')).to eq true
       expect(tar_contains_file('php/lib/librdkafka.so.1')).to eq true
 
       expect(tar_contains_file('php/lib/php/extensions/*/apcu.so')).to eq true
       expect(tar_contains_file('php/lib/php/extensions/*/ioncube.so')).to eq true
-      expect(tar_contains_file('php/lib/php/extensions/*/pdo_dblib.so')).to eq true
-      expect(tar_contains_file('php/lib/php/extensions/*/phalcon.so')).to eq true
       expect(tar_contains_file('php/lib/php/extensions/*/phpiredis.so')).to eq true
+      expect(tar_contains_file('php/lib/php/extensions/*/phalcon.so')).to eq true
 
       expect(tar_contains_file('php/lib/libGeoIP.so.1')).to eq true
       expect(tar_contains_file('php/lib/php/extensions/*/geoip.so')).to eq true
       expect(tar_contains_file('php/geoipdb/lib/geoip_downloader.rb')).to eq true
       expect(tar_contains_file('php/geoipdb/bin/download_geoip_db.rb')).to eq true
+      expect(tar_contains_file('php/geoipdb/dbs/GeoLiteCityv6.dat')).to eq true
+      expect(tar_contains_file('php/geoipdb/dbs/GeoLiteASNum.dat')).to eq true
+      expect(tar_contains_file('php/geoipdb/dbs/GeoLiteCountry.dat')).to eq true
+      expect(tar_contains_file('php/geoipdb/dbs/GeoIPv6.dat')).to eq true
+      expect(tar_contains_file('php/geoipdb/dbs/GeoLiteCity.dat')).to eq true
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,16 @@ RSpec.configure do |config|
     end
   end
 
+  config.before(:all, :run_geolite_php_tests) do
+    file_to_enable_geolite_db = File.join(Dir.pwd, 'BUNDLE_GEOIP_LITE')
+    File.open(file_to_enable_geolite_db, 'w') { |f| f.puts "true" }
+  end
+
+  config.after(:all, :run_geolite_php_tests) do
+    file_to_enable_geolite_db = File.join(Dir.pwd, 'BUNDLE_GEOIP_LITE')
+    FileUtils.rm(file_to_enable_geolite_db)
+  end
+
   def cleanup_docker_artifacts(docker_container_name)
     `docker stop #{docker_container_name}`
     `docker rm #{docker_container_name}`


### PR DESCRIPTION
I've added support for the geoip extension, plus support for downloading the required geoip databases.  There's an option to download at build time and package the "lite" version of the DB with the produced PHP binaries.  There's also the option to just package the scripts to download the files, so that those can be run during staging.  I plan to add something to the PHP build pack to take advantage of these scripts and easily run them at staging.  That'll be another pull request, hopefully soon.