### PR TITLE
Speed up libmemcached build.

### DIFF
--- a/recipe/php_common_recipes.rb
+++ b/recipe/php_common_recipes.rb
@@ -73,6 +73,15 @@ class LibmemcachedRecipe < BaseRecipe
   def url
     "https://launchpad.net/libmemcached/1.0/#{version}/+download/libmemcached-#{version}.tar.gz"
   end
+
+  def patch
+    system <<-eof
+      cd #{work_path}
+      sed -i '\\|include tests/include.am|d' Makefile.am
+      aclocal
+      automake --add-missing
+    eof
+  end
 end
 
 class LibRdKafkaRecipe < BaseRecipe

--- a/recipe/php_meal.rb
+++ b/recipe/php_meal.rb
@@ -158,7 +158,8 @@ class PhpMeal
       libxml2-dev
       libzip-dev
       libzookeeper-mt-dev
-      snmp-mibs-downloader)
+      snmp-mibs-downloader
+      automake)
   end
 
   def symlink_commands


### PR DESCRIPTION
Adjusts Makefile.am for libmemcached so that it doesn't build tests.  The tests are very slow and in my experience have never turned up any failures.  It seems like wasted time (IMHO), which can be significant when running lots of builds (like when the tests run).

Only downside to this change is that we have to install automake and autoconf to regenerate configure and Makefile.in.