### PR TITLE
Added recipes to build UnixODBC, PHP's odbc extension and PHP's pdo_odbc extension

### DIFF
--- a/recipe/php_common_recipes.rb
+++ b/recipe/php_common_recipes.rb
@@ -106,6 +106,15 @@ class LibmemcachedRecipe < BaseRecipe
   end
 end
 
+# We need to compile from source until Ubuntu packages version 2.3.0+
+#  The unixODBC library version changed from 1 to 2 at this point, so
+#  newer ODBC drivers won't work with the older library.
+class UnixOdbcRecipe < BaseRecipe
+  def url
+    "http://www.unixodbc.org/unixODBC-#{version}.tar.gz"
+  end
+end
+
 class LibRdKafkaRecipe < BaseRecipe
   def url
     "https://github.com/edenhill/librdkafka/archive/v#{version}.tar.gz"
@@ -186,6 +195,72 @@ class MemcachedPeclRecipe < PeclRecipe
       '--enable-memcached-json'
     ]
   end
+end
+
+class FakePeclRecipe < PeclRecipe
+  def download
+    # this copys an extension folder out of the PHP source director (i.e. `ext/<name>`)
+    # it pretends to download it by making a zip of the extension files
+    # that way the rest of the PeclRecipe works normally
+    files_hashs.each do |file|
+      path = URI(file[:url]).path.rpartition('-')[0] # only need path before the `-`, see url above
+      system <<-eof
+        echo 'tar czf "#{file[:local_path]}" -C "#{File.dirname(path)}" "#{File.basename(path)}"'
+        tar czf "#{file[:local_path]}" -C "#{File.dirname(path)}" "#{File.basename(path)}"
+      eof
+    end
+  end
+end
+
+class OdbcRecipe < FakePeclRecipe
+  def url
+    "file://#{@php_source}/ext/odbc-#{version}.tar.gz"
+  end
+
+  def configure_options
+    [
+      "--with-unixODBC=shared,#{@unixodbc_path}"
+    ]
+  end
+
+  def patch
+    # patching same issue mentioned here ->
+    #   https://github.com/docker-library/php/issues/103#issuecomment-271434109
+    system <<-eof
+      cd #{work_path}
+      echo 'AC_DEFUN([PHP_ALWAYS_SHARED],[])dnl' > temp.m4
+      echo >> temp.m4
+      cat config.m4 >> temp.m4
+      mv temp.m4 config.m4
+    eof
+  end
+
+  def setup_tar
+    system <<-eof
+      cp -a #{@unixodbc_path}/lib/libodbc.so* #{@php_path}/lib/
+      cp -a #{@unixodbc_path}/lib/libodbcinst.so* #{@php_path}/lib/
+    eof
+  end
+end
+
+class PdoOdbcRecipe < FakePeclRecipe
+  def url
+    "file://#{@php_source}/ext/pdo_odbc-#{version}.tar.gz"
+  end
+
+  def configure_options
+    [
+      "--with-pdo-odbc=unixODBC,#{@unixodbc_path}"
+    ]
+  end
+
+  def setup_tar
+    system <<-eof
+      cp -a #{@unixodbc_path}/lib/libodbc.so* #{@php_path}/lib/
+      cp -a #{@unixodbc_path}/lib/libodbcinst.so* #{@php_path}/lib/
+    eof
+  end
+
 end
 
 class OraclePdoRecipe < PeclRecipe

--- a/recipe/php_meal.rb
+++ b/recipe/php_meal.rb
@@ -20,7 +20,7 @@ class PhpMeal
     (@native_modules + @extensions).each do |recipe|
       recipe.instance_variable_set('@php_path', php_recipe.path)
 
-      if recipe.name == 'pdo_oci'
+      if recipe.name == 'pdo_oci' || recipe.name == 'odbc' || recipe.name == 'pdo_odbc'
         recipe.instance_variable_set('@version', @version)
         recipe.instance_variable_set('@php_source', "#{php_recipe.send(:tmp_path)}/php-#{@version}")
         recipe.instance_variable_set('@files', [{url: recipe.url, md5: nil}])
@@ -79,6 +79,8 @@ class PhpMeal
       @extensions.detect{|r| r.name=='oci8'}.setup_tar
       @extensions.detect{|r| r.name=='pdo_oci'}.setup_tar
     end
+    @extensions.detect{|r| r.name=='odbc'}&.setup_tar
+    @extensions.detect{|r| r.name=='pdo_odbc'}&.setup_tar
   end
 
   private
@@ -124,6 +126,10 @@ class PhpMeal
         recipe.instance_variable_set('@php_version', "php#{@major_version}")
       when 'phpiredis'
         recipe.instance_variable_set('@hiredis_path', @native_modules.detect{|r| r.name=='hiredis'}.path)
+      when 'odbc'
+        recipe.instance_variable_set('@unixodbc_path', @native_modules.detect{|r| r.name=='unixodbc'}.path)
+      when 'pdo_odbc'
+        recipe.instance_variable_set('@unixodbc_path', @native_modules.detect{|r| r.name=='unixodbc'}.path)
       end
     end
   end

--- a/spec/integration/php5_spec.rb
+++ b/spec/integration/php5_spec.rb
@@ -44,12 +44,15 @@ describe 'building a binary', :integration do
       expect(tar_contains_file('php/lib/libuv.so.1.0.0')).to eq true
       expect(tar_contains_file('php/lib/libsybdb.so.5')).to eq true
       expect(tar_contains_file('php/lib/librdkafka.so.1')).to eq true
+      expect(tar_contains_file('php/lib/libodbc.so')).to eq true
 
       expect(tar_contains_file('php/lib/php/extensions/*/apcu.so')).to eq true
       expect(tar_contains_file('php/lib/php/extensions/*/ioncube.so')).to eq true
       expect(tar_contains_file('php/lib/php/extensions/*/pdo_dblib.so')).to eq true
       expect(tar_contains_file('php/lib/php/extensions/*/phalcon.so')).to eq true
       expect(tar_contains_file('php/lib/php/extensions/*/phpiredis.so')).to eq true
+      expect(tar_contains_file('php/lib/php/extensions/*/odbc.so')).to eq true
+      expect(tar_contains_file('php/lib/php/extensions/*/pdo_odbc.so')).to eq true
 
       expect(tar_contains_file('php/lib/libGeoIP.so.1')).to eq true
       expect(tar_contains_file('php/lib/php/extensions/*/geoip.so')).to eq true

--- a/spec/integration/php71_spec.rb
+++ b/spec/integration/php71_spec.rb
@@ -41,6 +41,7 @@ describe 'building a binary', :integration do
       expect(tar_contains_file('php/lib/libcassandra.so.2')).to eq true
       expect(tar_contains_file('php/lib/libuv.so.1.0.0')).to eq true
       expect(tar_contains_file('php/lib/librdkafka.so.1')).to eq true
+      expect(tar_contains_file('php/lib/libodbc.so')).to eq true
 
       expect(tar_contains_file('php/lib/php/extensions/*/apcu.so')).to eq true
       # removing assertion until ioncube has PHP 7.1 support
@@ -50,6 +51,8 @@ describe 'building a binary', :integration do
       # phalcon does not support php 7.1.x yet
       # https://github.com/phalcon/cphalcon/issues/12444
       expect(tar_contains_file('php/lib/php/extensions/*/phalcon.so')).to eq false
+      expect(tar_contains_file('php/lib/php/extensions/*/odbc.so')).to eq true
+      expect(tar_contains_file('php/lib/php/extensions/*/pdo_odbc.so')).to eq true
 
       expect(tar_contains_file('php/lib/libGeoIP.so.1')).to eq true
       expect(tar_contains_file('php/lib/php/extensions/*/geoip.so')).to eq true

--- a/spec/integration/php7_spec.rb
+++ b/spec/integration/php7_spec.rb
@@ -40,11 +40,14 @@ describe 'building a binary', :integration do
       expect(tar_contains_file('php/lib/libcassandra.so.2')).to eq true
       expect(tar_contains_file('php/lib/libuv.so.1.0.0')).to eq true
       expect(tar_contains_file('php/lib/librdkafka.so.1')).to eq true
+      expect(tar_contains_file('php/lib/libodbc.so')).to eq true
 
       expect(tar_contains_file('php/lib/php/extensions/*/apcu.so')).to eq true
       expect(tar_contains_file('php/lib/php/extensions/*/ioncube.so')).to eq true
       expect(tar_contains_file('php/lib/php/extensions/*/phpiredis.so')).to eq true
       expect(tar_contains_file('php/lib/php/extensions/*/phalcon.so')).to eq true
+      expect(tar_contains_file('php/lib/php/extensions/*/odbc.so')).to eq true
+      expect(tar_contains_file('php/lib/php/extensions/*/pdo_odbc.so')).to eq true
 
       expect(tar_contains_file('php/lib/libGeoIP.so.1')).to eq true
       expect(tar_contains_file('php/lib/php/extensions/*/geoip.so')).to eq true


### PR DESCRIPTION
Notes:

It's a requirement to build UnixODBC from source because the version packaged with
Ubuntu Trusty is older and there has been a major version change to the library.
Thus any ODBC driver compiled against the newer version of UnixODBC will not be
compatible with the older version.  This can be removed when Ubuntu packages v2.3.0+
of UnixODBC.

Because we compile UnixODBC manually and this happens after PHP is compiled, we cannot
build the extensions as a part of PHP.  To work around this, we copy the extension
files out of the PHP source and build them like a stand-alone PECL library, after
UnixODBC has been built.  This causes a minor issue with the ODBC extension, which
requires a small patch to its build files.  See the link in the comment for more
details.