### PR TITLE
Use libmemcached built from source, not from Ubuntu packages.

### DIFF
--- a/recipe/php7_recipe.rb
+++ b/recipe/php7_recipe.rb
@@ -90,7 +90,7 @@ class Php7Recipe < BaseRecipe
       cp -a /usr/lib/libmcrypt.so* #{path}/lib
       cp -a /usr/lib/libaspell.so* #{path}/lib
       cp -a /usr/lib/libpspell.so* #{path}/lib
-      cp -a /usr/lib/x86_64-linux-gnu/libmemcached.so* #{path}/lib
+      cp -a #{@libmemcached_path}/lib/libmemcached.so* #{path}/lib/
       cp -a /usr/local/lib/x86_64-linux-gnu/libcassandra.so* #{path}/lib
       cp -a /usr/local/lib/libuv.so* #{path}/lib
       cp -a /usr/lib/librdkafka.so* #{path}/lib

--- a/recipe/php_meal.rb
+++ b/recipe/php_meal.rb
@@ -147,7 +147,7 @@ class PhpMeal
   end
 
   def php7_apt_packages
-    php_common_apt_packages + %w(libmemcached-dev)
+    php_common_apt_packages
   end
 
   def php_common_apt_packages


### PR DESCRIPTION
Don't install libmemcached from Ubuntu packages and build from source instead.  The modules from Ubuntu are older and have a different library version.  This is part of [this issue](https://github.com/cloudfoundry/php-buildpack/issues/223).