### PR TITLE
Pull in libraries needed by the gnupg PHP extension.

### DIFF
--- a/recipe/php5_recipe.rb
+++ b/recipe/php5_recipe.rb
@@ -102,6 +102,9 @@ class Php5Recipe < BaseRecipe
       cp -a /usr/lib/x86_64-linux-gnu/libsybdb.so* #{path}/lib/
       cp -a /usr/lib/librdkafka.so* #{path}/lib
       cp -a /usr/lib/x86_64-linux-gnu/libGeoIP.so* #{path}/lib/
+      cp -a /usr/lib/x86_64-linux-gnu/libgpgme.so* #{path}/lib/
+      cp -a /usr/lib/x86_64-linux-gnu/libassuan.so* #{path}/lib/
+      cp -a /usr/lib/x86_64-linux-gnu/libgpg-error.so* #{path}/lib/
 
       # Remove unused files
       rm "#{path}/etc/php-fpm.conf.default"

--- a/recipe/php7_recipe.rb
+++ b/recipe/php7_recipe.rb
@@ -95,6 +95,9 @@ class Php7Recipe < BaseRecipe
       cp -a /usr/local/lib/libuv.so* #{path}/lib
       cp -a /usr/lib/librdkafka.so* #{path}/lib
       cp -a /usr/lib/x86_64-linux-gnu/libGeoIP.so* #{path}/lib/
+      cp -a /usr/lib/x86_64-linux-gnu/libgpgme.so* #{path}/lib/
+      cp -a /usr/lib/x86_64-linux-gnu/libassuan.so* #{path}/lib/
+      cp -a /usr/lib/x86_64-linux-gnu/libgpg-error.so* #{path}/lib/
     eof
 
     if IonCubeRecipe.build_ioncube?(version)


### PR DESCRIPTION
Also required for building gnupg extension and [this issue](https://github.com/cloudfoundry/php-buildpack/issues/222).