### PR TITLE
Add custom recipe for building redis extension with igbinary & lzf support

### DIFF
--- a/recipe/php_common_recipes.rb
+++ b/recipe/php_common_recipes.rb
@@ -370,6 +370,17 @@ class PHPIRedisRecipe < PeclRecipe
   end
 end
 
+class RedisPeclRecipe < PeclRecipe
+  def configure_options
+    [
+      "--with-php-config=#{@php_path}/bin/php-config",
+      "--enable-redis-igbinary",
+      "--enable-redis-lzf",
+      "--with-liblzf=no"
+    ]
+  end
+end
+
 class PHPProtobufPeclRecipe < PeclRecipe
   def url
     "https://github.com/allegro/php-protobuf/archive/v#{version}.tar.gz"


### PR DESCRIPTION
Should resolve: https://github.com/cloudfoundry/php-buildpack/issues/273