### PR TITLE
Add support for mod_auth_openidc into HTTPD builds

### DIFF
--- a/recipe/httpd_meal.rb
+++ b/recipe/httpd_meal.rb
@@ -74,7 +74,7 @@ class HTTPdRecipe < BaseRecipe
     system <<-eof
       cd #{path}
 
-      rm -rf build/ cgi-bin/ error/ icons/ include/ man/ manual/ htdocs/
+      rm -rf cgi-bin/ error/ icons/ include/ man/ manual/ htdocs/
       rm -rf conf/extra/* conf/httpd.conf conf/httpd.conf.bak conf/magic conf/original
 
       mkdir -p lib

--- a/recipe/httpd_meal.rb
+++ b/recipe/httpd_meal.rb
@@ -85,7 +85,24 @@ class HTTPdRecipe < BaseRecipe
       mkdir -p "./lib/iconv"
       cp "#{@apr_iconv_path}/lib/libapriconv-1.so.0" ./lib
       cp "#{@apr_iconv_path}/lib/iconv/"*.so ./lib/iconv/
+      cp /usr/lib/x86_64-linux-gnu/libcjose.so* ./lib/
+      cp /usr/lib/x86_64-linux-gnu/libhiredis.so* ./lib/
+      cp /usr/lib/x86_64-linux-gnu/libjansson.so* ./lib/
     eof
+  end
+end
+
+class ModAuthOpenidcRecipe < BaseRecipe
+  def url
+    "https://github.com/zmartzone/mod_auth_openidc/releases/download/v#{version}/mod_auth_openidc-#{version}.tar.gz"
+  end
+
+  def configure_options
+    ENV['APR_LIBS'] = `#{@apr_path}/bin/apr-1-config --link-ld --libs`
+    ENV['APR_CFLAGS'] = `#{@apr_path}/bin/apr-1-config --cflags --includes`
+    [
+      "--with-apxs2=#{@httpd_path}/bin/apxs"
+    ]
   end
 end
 
@@ -100,12 +117,23 @@ class HTTPdMeal
 
   def cook
     run('apt update') or raise 'Failed to apt update'
-    run('apt-get install -y libldap2-dev') or raise 'Failed to install libldap2-dev'
+    run('apt-get install -y libldap2-dev libjansson-dev libcjose-dev libhiredis-dev') or raise 'Failed to install libldap2-dev'
 
     apr_recipe.cook
     apr_iconv_recipe.cook
     apr_util_recipe.cook
     httpd_recipe.cook
+
+    # this symlink is needed so that modules can call `apxs`
+    #  putting it here because we only need to do it once
+    system <<-eof
+      cd /app
+      if ! [ -L "/app/httpd" ]; then
+        ln -s "#{httpd_recipe.path}" httpd
+      fi
+    eof
+
+    mod_auth_openidc_recipe.cook unless ENV['STACK'] == 'cflinuxfs2'
   end
 
   def url
@@ -145,7 +173,15 @@ class HTTPdMeal
     httpd_recipe.send(:files_hashs) +
       apr_recipe.send(:files_hashs)       +
       apr_iconv_recipe.send(:files_hashs) +
-      apr_util_recipe.send(:files_hashs)
+      apr_util_recipe.send(:files_hashs) +
+      mod_auth_openidc_recipe.send(:files_hashs)
+  end
+
+  def mod_auth_openidc_recipe
+    @mod_auth_openidc ||= ModAuthOpenidcRecipe.new('mod-auth-openidc', '2.3.8',
+      httpd_path: httpd_recipe.path,
+      apr_path: apr_recipe.path,
+      md5: 'd6abc2f68dabf5d2557400af2499f500')
   end
 
   def httpd_recipe


### PR DESCRIPTION
This PR adds the mod_auth_openidc HTTPD module (license Apache v2) into the build scripts. This will conditionally build the module for the cflinuxfs3 stack (cflinuxfs2 could technically be made to work, but there's missing dependencies in `apt` so it would be a lot more work).

From the project page:

>mod_auth_openidc is an authentication/authorization module for the Apache 2.x HTTP server that functions as an OpenID Connect Relying Party, authenticating users against an OpenID Connect Provider. It can also function as an OAuth 2.0 Resource Server, validating OAuth 2.0 bearer access tokens presented by OAuth 2.0 Clients.

https://github.com/zmartzone/mod_auth_openidc/

This will allow users to add oauth2 support to their apps without needing to adjust any code.