### PR TITLE
Remove sudo when installing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This tool provides a mechanism for building binaries for the Cloud Foundry build
 
 # Usage
 
-The scripts are meant to be run on a Cloud Foundry [stack](https://docs.cloudfoundry.org/concepts/stacks.html).
+The scripts are meant to be run as root on a Cloud Foundry [stack](https://docs.cloudfoundry.org/concepts/stacks.html).
 
 ## Running within Docker
 

--- a/bin/binary-builder
+++ b/bin/binary-builder
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 gem update --system
-gem install bundler
 bundle config mirror.https://rubygems.org ${RUBYGEM_MIRROR}
 bundle install
 bundle exec ./bin/binary-builder.rb "$@"

--- a/recipe/php_meal.rb
+++ b/recipe/php_meal.rb
@@ -32,9 +32,9 @@ class PhpMeal
 
   def cook
     system <<-eof
-      sudo apt-get update
-      sudo apt-get -y upgrade
-      sudo apt-get -y install #{apt_packages}
+      apt-get update
+      apt-get -y upgrade
+      apt-get -y install #{apt_packages}
       #{install_libuv}
       #{install_argon2}
       #{symlink_commands}


### PR DESCRIPTION
Trying again after changing organization membership settings:
I have a customer who is attempting to use binary-builder to build their custom version of the PHP buildpack on Concourse inside their corporate network. The concourse installation is configured to set the appropriate environment variables so the correct http and https proxies are used by utilities such as apt-get. As a result of using sudo to run these commands, a new shell is instantiated which does not have those proxy settings and thus these apt-get calls will fail. Assuming the main use of this script would be on concourse, the use of sudo should be extraneous as we are already operating as root. That is a big assumption I would admit. Also, there are other places in binary-builder where the apt-get commands are not executed with sudo thus it seemed safe to me to remove the use of sudo. Thanks.