### PR TITLE
Nginx add http_sub_module

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ docker run -w /binary-builder -v `pwd`:/binary-builder -it cloudfoundry/cflinuxf
 
 For an example of what this file looks like, see: [PHP 5](https://github.com/cloudfoundry/buildpacks-ci/blob/master/tasks/build-binary-new/php-extensions.yml), [PHP 7.0 & 7.1](https://github.com/cloudfoundry/buildpacks-ci/blob/master/tasks/build-binary-new/php7-extensions.yml) & [PHP 7.2](https://github.com/cloudfoundry/buildpacks-ci/blob/master/tasks/build-binary-new/php72-extensions.yml).
 
-## Building nginx
+# Building nginx
 
-NGinx uses GPG keys to verify the source tarball, so you'll need something like the following code to build the NGinx binary:
+Nginx uses GPG keys to verify the source tarball, so you'll need something like the following code to build the NGinx binary:
 
 ```
 version=1.15.9

--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ docker run -w /binary-builder -v `pwd`:/binary-builder -it cloudfoundry/cflinuxf
 
 For an example of what this file looks like, see: [PHP 5](https://github.com/cloudfoundry/buildpacks-ci/blob/master/tasks/build-binary-new/php-extensions.yml), [PHP 7.0 & 7.1](https://github.com/cloudfoundry/buildpacks-ci/blob/master/tasks/build-binary-new/php7-extensions.yml) & [PHP 7.2](https://github.com/cloudfoundry/buildpacks-ci/blob/master/tasks/build-binary-new/php72-extensions.yml).
 
+## Building nginx
+
+NGinx uses GPG keys to verify the source tarball, so you'll need something like the following code to build the NGinx binary:
+
+```
+version=1.15.9
+gpg_signature_url="http://nginx.org/download/nginx-${version}.tar.gz.asc"
+gpg_signature=`curl -sL ${gpg_signature_url}`
+
+docker run -w /binary-builder -v `pwd`:/binary-builder \
+  -it cloudfoundry/cflinuxfs2 ./bin/binary-builder \
+  --name=nginx-static --gpg-rsa-key-id=A1C052F8 \
+  --version=$version --gpg-signature="${gpg_signature}"
+```
+
 # Contributing
 
 Find our guidelines [here](./CONTRIBUTING.md).

--- a/bin/binary-builder
+++ b/bin/binary-builder
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-gem update --system
-gem install bundler --no-document -f
+gem update --system --no-document
+gem install bundler --no-document -f 
 bundle config mirror.https://rubygems.org ${RUBYGEM_MIRROR}
 bundle install
 bundle exec ./bin/binary-builder.rb "$@"

--- a/recipe/nginx.rb
+++ b/recipe/nginx.rb
@@ -14,6 +14,7 @@ class NginxRecipe < BaseRecipe
       '--with-http_random_index_module',
       '--with-http_secure_link_module',
       '--with-http_stub_status_module',
+      '--with-http_sub_module',
       '--without-http_uwsgi_module',
       '--without-http_scgi_module',
       '--with-pcre',


### PR DESCRIPTION
Addresses https://github.com/cloudfoundry/nginx-buildpack/issues/14 by
adding ngx_http_sub_module to nginx recipe

Speeds up run time in `bundle update` step by adding `--no-document`

Provides some hints on how to build nginx in the README