### PR TITLE
Php extension ssh2

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,12 @@ To build PHP, you also need to pass in a YAML file containing information about 
 ```bash
 docker run -w /binary-builder -v `pwd`:/binary-builder -it cloudfoundry/cflinuxfs3 bash
 export STACK=cflinuxfs3
-./bin/binary-builder --name=php --version=7.1.29 --md5=ae625e0cfcfdacea3e7a70a075e47155 --php-extensions-file=./php71-extensions.yml
+./bin/binary-builder --name=php7 --version=7.3.14 --sha256=6aff532a380b0f30c9e295b67dc91d023fee3b0ae14b4771468bf5dda4cbf108 --php-extensions-file=./php7-extensions.yml
 ```
 
-For an example of what this file looks like, see: [PHP 5](https://github.com/cloudfoundry/buildpacks-ci/blob/master/tasks/build-binary-new/php-extensions.yml), [PHP 7.0 & 7.1](https://github.com/cloudfoundry/buildpacks-ci/blob/master/tasks/build-binary-new/php7-extensions.yml) & [PHP 7.2](https://github.com/cloudfoundry/buildpacks-ci/blob/master/tasks/build-binary-new/php72-extensions.yml).
+For an example of what this file looks like, see: [php7-base-extensions.yml](https://github.com/cloudfoundry/buildpacks-ci/tree/master/tasks/build-binary-new) and the various `php*-extensions-patch.yml` files in that same directory. Patch files adjust the base-extensions.yml file by adding/removing extensions. The `--php-extensions-file` argument will need the base-extensions file with one of the patch files applied. That normally happens automatically through the pipeline, so if you are building manually you need to manually create this file.
+
+**TIP** If you are updating or building a specific PHP extension, remove everything except that specific extension from your `--php-extensions-file` file. This will decrease the build times & make it easier for you to test your changes.
 
 # Building nginx
 

--- a/recipe/php7_recipe.rb
+++ b/recipe/php7_recipe.rb
@@ -108,6 +108,7 @@ class Php7Recipe < BaseRecipe
       cp -a /usr/lib/x86_64-linux-gnu/librecode.so* #{path}/lib/
       cp -a /usr/lib/x86_64-linux-gnu/libtommath.so* #{path}/lib/
       cp -a /usr/lib/x86_64-linux-gnu/libmaxminddb.so* #{path}/lib/
+      cp -a /usr/lib/x86_64-linux-gnu/libssh2.so* #{path}/lib/
     eof
 
     if IonCubeRecipe.build_ioncube?(version)

--- a/recipe/php_meal.rb
+++ b/recipe/php_meal.rb
@@ -179,7 +179,8 @@ class PhpMeal
       libenchant-dev
       firebird-dev
       librecode-dev
-      libwebp-dev)
+      libwebp-dev
+      libssh2-1-dev)
   end
 
   def install_libuv


### PR DESCRIPTION
This adds the libssh library so that we can build & bundle the php ssh2 extension.

https://github.com/cloudfoundry/binary-builder/issues/48
https://github.com/cloudfoundry/php-buildpack/issues/336