### PR TITLE
archive_recipe: compress tars with --dereference flag

### DIFF
--- a/lib/archive_recipe.rb
+++ b/lib/archive_recipe.rb
@@ -30,7 +30,7 @@ class ArchiveRecipe
           `zip #{File.join(output_dir, @recipe.archive_filename)} -r .`
         end
       else
-        `ls -A #{dir} | xargs tar czf #{@recipe.archive_filename} -C #{dir}`
+        `ls -A #{dir} | xargs tar --dereference -czf #{@recipe.archive_filename} -C #{dir}`
       end
       puts 'OK'
     end


### PR DESCRIPTION
With the `--dereference` flag, tar follows symlinks, archives and dump
the files they point to, replacing the symlink.

For e.g. the following:
```
lrwxrwxrwx 1    39 libgpg-error.so -> /lib/x86_64-linux-gnu/libgpg-error.so.0
```
will now become:
```
-rw-r--r-- 1 84032 libgpg-error.so
```
due to the `--dereference` flag.

**Pros**:

* Avoids the possiblity of archive extraction vulnerabilities, where an
attacker may gain access to parts of the file system outside of the
target folder on extraction.
See e.g. https://snyk.io/blog/severe-security-vulnerability-in-bowers-zip-archive-extraction/

* The resultant dependency tarball will pass all systems testing against the
above stated vuln.

**Cons**:

* Increases the compressed dependency archive size since symlinks have
to be replaced by their targets during compress-time. The compress-time
filesystem is expected to have the target available.

For e.g. the following:
```
lrwxrwxrwx 1     14 libuv.so -> libuv.so.1.0.0
lrwxrwxrwx 1     14 libuv.so.1 -> libuv.so.1.0.0
-rwxr-xr-x 1 747232 libuv.so.1.0.0
```
will now become:
```
-rwxr-xr-x 3 747232 libuv.so
-rwxr-xr-x 3 747232 libuv.so.1
-rwxr-xr-x 3 747232 libuv.so.1.0.0
```

See issue filed on a buildpack that consumes dependencies built using the binary-builder: https://github.com/paketo-buildpacks/php-dist/issues/253