### PR TITLE
archive_recipe: compress tar with deference only for php

### DIFF
--- a/lib/archive_recipe.rb
+++ b/lib/archive_recipe.rb
@@ -30,7 +30,11 @@ class ArchiveRecipe
           `zip #{File.join(output_dir, @recipe.archive_filename)} -r .`
         end
       else
-        `ls -A #{dir} | xargs tar --dereference -czf #{@recipe.archive_filename} -C #{dir}`
+        if @recipe.name == 'php'
+          `ls -A #{dir} | xargs tar --dereference -czf #{@recipe.archive_filename} -C #{dir}`
+        else
+          `ls -A #{dir} | xargs tar czf #{@recipe.archive_filename} -C #{dir}`
+        end
       end
       puts 'OK'
     end


### PR DESCRIPTION
This makes the changes done in #56 to only affect php.
We noticed undesired consequences in node and thus is only done in php for now.

As said in #56, the `--dereference` flag replaces symlinks with their targets. This unfortunately assumes that any symlinked
executable would be portable and would not contain invocations of other files/executable via relative filepaths. This
assumption is not true for npm executable in the node dependency as shown in the following example.


```
#without --dereference
‣ ls -al bin/
drwxr-xr-x 2 ubuntu ubuntu     4096 Aug 31 16:01 .
drwx------ 6 ubuntu ubuntu     4096 Aug 31 16:01 ..
-rwxr-xr-x 1 ubuntu ubuntu 78475568 Aug 31 16:01 node
lrwxrwxrwx 1 ubuntu ubuntu       38 Aug 31 16:01 npm -> ../lib/node_modules/npm/bin/npm-cli.js
lrwxrwxrwx 1 ubuntu ubuntu       38 Aug 31 16:01 npx -> ../lib/node_modules/npm/bin/npx-cli.js

# with --dereference
 ‣ ls -al bin/
total 76836
drwxr-xr-x 2 ubuntu ubuntu     4096 Sep 28 12:19 .
drwx------ 6 ubuntu ubuntu     4096 Sep 28 12:19 ..
-rwxr-xr-x 1 ubuntu ubuntu 78656688 Sep 28 12:19 node
-rwxr-xr-x 2 ubuntu ubuntu     4706 Sep 28 12:19 npm
-rwxr-xr-x 2 ubuntu ubuntu      177 Sep 28 12:19 npx
```
In the case with `--dereference`, when the npm executable is invoked, it fails with `Error: Cannot find module '../lib/utils/unsupported.js'` because the now deferenced executable has lost the context of the relative path that should in reality point to  `/lib/node_modules/npm/bin/../lib/utils/<file>.js` (cleaned path: `lib/node_modules/npm/lib/utils/<file>.js`)
