### PR TITLE
Update go version for binary builder

### DIFF
--- a/cflinuxfs4/go-version.yml
+++ b/cflinuxfs4/go-version.yml
@@ -1,3 +1,3 @@
 go:
-  - version: 1.12.4
-    sha256: d7d1f1f88ddfe55840712dc1747f37a790cbcaa448f6c9cf51bbe10aa65442f5
+  - version: 1.20.1
+    sha256: 000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02

--- a/go-version.yml
+++ b/go-version.yml
@@ -1,3 +1,3 @@
 go:
-  - version: 1.12.4
-    sha256: d7d1f1f88ddfe55840712dc1747f37a790cbcaa448f6c9cf51bbe10aa65442f5
+  - version: 1.20.1
+    sha256: 000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02


### PR DESCRIPTION
The current go version, 1.12.4, is unsupported in Dynatrace.
This PR should resolve [this HWC](https://github.com/cloudfoundry/hwc-buildpack/issues/107) issue.