### PR TITLE
httpd: do not hardcode versions of apr

### DIFF
--- a/cflinuxfs4/recipe/httpd_meal.rb
+++ b/cflinuxfs4/recipe/httpd_meal.rb
@@ -174,6 +174,12 @@ class HTTPdMeal
     end
   end
 
+  def latest_github_version(repo)
+    puts "Getting latest tag from #{repo}..."
+    repo = "https://github.com/#{repo}"
+    return `git -c 'versionsort.suffix=-' ls-remote --exit-code --refs --sort='version:refname' --tags #{repo} '*.*.*' | tail -1 | cut -d/ --fields=3`.strip
+  end
+
   def files_hashs
     httpd_recipe.send(:files_hashs) +
       apr_recipe.send(:files_hashs)       +
@@ -198,17 +204,18 @@ class HTTPdMeal
   end
 
   def apr_util_recipe
-    @apr_util_recipe ||= AprUtilRecipe.new('apr-util', '1.6.3', apr_path: apr_recipe.path,
-                                                                apr_iconv_path: apr_iconv_recipe.path,
-                                                                md5: 'b2b6fb440548869dc228535e339f619b')
+    apr_util_version = latest_github_version("apache/apr-util")
+    @apr_util_recipe ||= AprUtilRecipe.new('apr-util', apr_util_version, apr_path: apr_recipe.path,
+                                                                apr_iconv_path: apr_iconv_recipe.path)
   end
 
   def apr_iconv_recipe
-    @apr_iconv_recipe ||= AprIconvRecipe.new('apr-iconv', '1.2.2', apr_path: apr_recipe.path,
-                                                                   md5: '60ae6f95ee4fdd413cf7472fd9c776e3')
+    apr_iconv_version = latest_github_version("apache/apr-iconv")
+    @apr_iconv_recipe ||= AprIconvRecipe.new('apr-iconv', apr_iconv_version, apr_path: apr_recipe.path)
   end
 
   def apr_recipe
-    @apr_recipe ||= AprRecipe.new('apr', '1.7.2', md5: '0af3415d905e8780e37540b3ab76c541')
+    apr_version = latest_github_version("apache/apr")
+    @apr_recipe ||= AprRecipe.new('apr', apr_version)
   end
 end

--- a/recipe/httpd_meal.rb
+++ b/recipe/httpd_meal.rb
@@ -113,6 +113,7 @@ class HTTPdMeal
     @name    = name
     @version = version
     @options = options
+    update_git
   end
 
   def cook
@@ -171,6 +172,25 @@ class HTTPdMeal
     end
   end
 
+  def latest_github_version(repo)
+    puts "Getting latest tag from #{repo}..."
+    repo = "https://github.com/#{repo}"
+    return `git -c 'versionsort.suffix=-' ls-remote --exit-code --refs --sort='version:refname' --tags #{repo} '*.*.*' | tail -1 | cut -d/ --fields=3`.strip
+  end
+
+  def update_git
+    # This is done because we rely on git's ls-remote that was introduced in 2.18.
+    # cflinuxfs3/bionic comes with an older version of git.
+    puts "Updating git to latest version..."
+    system <<-EOF
+      #!/bin/sh
+      apt-get -y update
+      apt-get -y install software-properties-common
+      add-apt-repository -y ppa:git-core/ppa
+      apt-get -y update && apt-get -y install git
+    EOF
+  end
+
   def files_hashs
     hashes = httpd_recipe.send(:files_hashs) +
       apr_recipe.send(:files_hashs)       +
@@ -197,17 +217,18 @@ class HTTPdMeal
   end
 
   def apr_util_recipe
-    @apr_util_recipe ||= AprUtilRecipe.new('apr-util', '1.6.3', apr_path: apr_recipe.path,
-                                                                apr_iconv_path: apr_iconv_recipe.path,
-                                                                md5: 'b2b6fb440548869dc228535e339f619b')
+    apr_util_version = latest_github_version("apache/apr-util")
+    @apr_util_recipe ||= AprUtilRecipe.new('apr-util', apr_util_version, apr_path: apr_recipe.path,
+                                                                apr_iconv_path: apr_iconv_recipe.path)
   end
 
   def apr_iconv_recipe
-    @apr_iconv_recipe ||= AprIconvRecipe.new('apr-iconv', '1.2.2', apr_path: apr_recipe.path,
-                                                                   md5: '60ae6f95ee4fdd413cf7472fd9c776e3')
+    apr_iconv_version = latest_github_version("apache/apr-iconv")
+    @apr_iconv_recipe ||= AprIconvRecipe.new('apr-iconv', apr_iconv_version, apr_path: apr_recipe.path)
   end
 
   def apr_recipe
-    @apr_recipe ||= AprRecipe.new('apr', '1.7.2', md5: '0af3415d905e8780e37540b3ab76c541')
+    apr_version = latest_github_version("apache/apr")
+    @apr_recipe ||= AprRecipe.new('apr', apr_version)
   end
 end


### PR DESCRIPTION
Use github mirror to figure out their latest released version and use them in the httpd dependency build process.

Mirrors that host apr* libraries remove older versions when newer versions are released.

See similar issues addressed in the paketo project:
https://github.com/paketo-buildpacks/httpd/pull/470
https://github.com/paketo-buildpacks/httpd/pull/472

Fixes #70 
Branch validated in https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/build-httpd-latest/builds/44