### PR TITLE
Add libmagickwand-dev libmagickcore-dev to cflinuxfs4 php compilation

### DIFF
--- a/cflinuxfs4/recipe/php_meal.rb
+++ b/cflinuxfs4/recipe/php_meal.rb
@@ -145,6 +145,8 @@ class PhpMeal
        libjpeg-dev
        libkrb5-dev
        libldap2-dev
+       libmagickwand-dev
+       libmagickcore-dev
        libmaxminddb-dev
        libmcrypt-dev
        libmemcached-dev


### PR DESCRIPTION
# Context
Latest cflinuxfs4 builds for PHP were failing for the same reason:
```bash
checking ImageMagick MagickWand API configuration program... checking Testing /usr/local/bin/MagickWand-config... Doesn't exist
checking Testing /usr/bin/MagickWand-config... Doesn't exist
checking Testing /usr/sbin/bin/MagickWand-config... Doesn't exist
checking Testing /opt/bin/MagickWand-config... Doesn't exist
checking Testing /opt/local/bin/MagickWand-config... Doesn't exist
checking Testing /opt/homebrew/bin/MagickWand-config... Doesn't exist
configure: error: not found. Please provide a path to MagickWand-config or Wand-config program.
```

After a quick search, looks like we need to install 2 new packages before the compilation process.

# Solution
Add `libmagickwand-dev` `libmagickcore-dev` as a dependency package to the PHP Meal recipe.