### PR TITLE
specs: support aws assume role

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ The project backlog is on [Pivotal Tracker](https://www.pivotaltracker.com/proje
 
 # Running the tests
 
-The integration test suite includes specs that test the functionality for building [PHP with Oracle client libraries](./PHP-Oracle.md). These tests are tagged `:run_oracle_php_tests` and require access to an S3 bucket containing the Oracle client libraries. This is configured using the environment variables `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY`
+The integration test suite includes specs that test the functionality for building [PHP with Oracle client libraries](./PHP-Oracle.md). These tests are tagged `:run_oracle_php_tests` and require access to an S3 bucket containing the Oracle client libraries. This is configured using the environment variables `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY`.
+
+Optionally provide `AWS_ASSUME_ROLE_ARN` to assume a role.
 
 If you do not need to test this functionality, exclude the tag `:run_oracle_php_tests` when you run `rspec`.

--- a/cflinuxfs4/README.md
+++ b/cflinuxfs4/README.md
@@ -85,4 +85,6 @@ The project backlog is on [Pivotal Tracker](https://www.pivotaltracker.com/proje
 
 The integration test suite includes specs that test the functionality for building [PHP with Oracle client libraries](./PHP-Oracle.md). These tests are tagged `:run_oracle_php_tests` and require access to an S3 bucket containing the Oracle client libraries. This is configured using the environment variables `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY`
 
+Optionally provide `AWS_ASSUME_ROLE_ARN` to assume a role.
+
 If you do not need to test this functionality, exclude the tag `:run_oracle_php_tests` when you run `rspec`.


### PR DESCRIPTION
All pipeline jobs are moving away from direct AWS access to access via a service-user that can assume a role with privileges. See https://github.com/cloudfoundry/buildpacks-ci/pull/318

The pipeline for the specs test is currently red. This change doesn't attempt to fix that.