### PR TITLE
Add `libgd-dev` to packages (required to build gd)

### DIFF
--- a/recipe/php_common_recipes.rb
+++ b/recipe/php_common_recipes.rb
@@ -256,25 +256,6 @@ class FakePeclRecipe < PeclRecipe
 end
 
 
-class Gd72and73FakePeclRecipe < FakePeclRecipe
-  def configure_options
-    baseOpts = [
-      "--with-jpeg-dir",
-      "--with-png-dir",
-      "--with-xpm-dir",
-      "--with-freetype-dir",
-      "--with-webp-dir",
-      "--with-zlib-dir",
-    ]
-
-    if version.start_with?("7.2")
-      return baseOpts.push("--enable-gd-jis-conv")
-    else
-      return baseOpts.push("--with-gd-jis-conv")
-    end
-  end
-end
-
 class Gd74FakePeclRecipe < FakePeclRecipe
   # how to build gd.so in PHP 7.4 changed dramatically
   #  In 7.4+, you can just use libgd from Ubuntu

--- a/recipe/php_meal.rb
+++ b/recipe/php_meal.rb
@@ -143,6 +143,7 @@ class PhpMeal
       libedit-dev
       libenchant-dev
       libexpat1-dev
+      libgd-dev
       libgdbm-dev
       libgeoip-dev
       libgmp-dev


### PR DESCRIPTION
# Context

PHP builds for version `8.x` are failing on the `cflinuxfs3` stack when attempting to compile the `gd` extension. [Ref](https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/build-php-8.0.x/builds/85#L64706e48:1847)


Error:

```bash
Extracting gd-8.0.29.tar.gz into /tmp/x86_64-linux-gnu/ports/gd/8.0.29... OK
Running 'phpize' for gd 8.0.29... OK
Running 'configure' for gd 8.0.29... ERROR, review '/tmp/x86_64-linux-gnu/ports/gd/8.0.29/configure.log' to see what happened. Last lines are:
========================================================================
checking for nawk... nawk
checking if nawk is broken... no
checking for GD support... yes, shared
checking for external libgd... yes
checking for libwebp... no
checking for libjpeg... no
checking for libXpm... no
checking for FreeType 2... no
checking whether to enable JIS-mapped Japanese font support in GD... no
checking for gdlib >= 2.1.0... no
configure: error: Package requirements (gdlib >= 2.1.0) were not met:

No package 'gdlib' found
```

Not sure how the previous builds worked without errors because this library was not present before.