### PR TITLE
Pin Bundler version in cflinuxfs3 binary-builder logic

### DIFF
--- a/bin/binary-builder
+++ b/bin/binary-builder
@@ -5,7 +5,7 @@
 export DEBIAN_DISABLE_RUBYGEMS_INTEGRATION=foo
 
 gem update --system --no-document -q --silent > /dev/null
-gem install bundler --no-document -f -q --silent > /dev/null
+gem install bundler:2.4.22  --no-document -f -q --silent > /dev/null
 bundle config mirror.https://rubygems.org ${RUBYGEM_MIRROR}
 bundle install
 bundle exec ./bin/binary-builder.rb "$@"


### PR DESCRIPTION
# Context

New versions of bundler `>=2.5.x` requires Ruby 3+. Since we still support `cflinuxfs3` dependencies, we need to pin the version installed to the latest version that works for Ruby 2.7.