### PR TITLE
Update python version used to build node  >= 22.x

### DIFF
--- a/recipe/node.rb
+++ b/recipe/node.rb
@@ -37,10 +37,10 @@ class NodeRecipe < BaseRecipe
   end
 
   def configure
-    if Gem::Version.new(version) >= Gem::Version.new('16.0.0')
-      execute('configure', %w(python3 configure) + computed_options)
+    if Gem::Version.new(version) >= Gem::Version.new('22.0.0')
+      execute('configure', %w(python3.8 configure) + computed_options)
     else
-      execute('configure', %w(python configure) + computed_options)
+      execute('configure', %w(python3 configure) + computed_options)
     end
   end
 end


### PR DESCRIPTION
# Context

After some investigation, I realized that `Node >=22.x`  requires a Python version `>= 3.8 `. The Python version will be provided by the `buildpacks-ci` task.

Also, we don't support any Node version `<= 18` so the assert no longer applies.