### PR TITLE
Fix errors with node 22.x in cflinuxfs3 (skip this line)

### DIFF
--- a/recipe/node.rb
+++ b/recipe/node.rb
@@ -37,10 +37,6 @@ class NodeRecipe < BaseRecipe
   end
 
   def configure
-    if Gem::Version.new(version) >= Gem::Version.new('22.0.0')
-      execute('configure', %w(python3.8 configure) + computed_options)
-    else
-      execute('configure', %w(python3 configure) + computed_options)
-    end
+    execute('configure', %w(python3 configure) + computed_options)
   end
 end


### PR DESCRIPTION
# Context

We decided not to ship Node version `22.x` for `cflinuxfs3`. I am just rolling back the changes made before.