### PR TITLE
fix dangling ref to deleted obj

### DIFF
--- a/cflinuxfs4/bin/binary-builder.rb
+++ b/cflinuxfs4/bin/binary-builder.rb
@@ -19,8 +19,7 @@ recipes = {
   'godep' => GoDepMeal,
   'glide' => GlideRecipe,
   'go' => GoRecipe,
-  'dep' => DepRecipe,
-  'hwc' => HwcRecipe
+  'dep' => DepRecipe
 }
 
 options = {}


### PR DESCRIPTION
HWCRecipe was deleted in https://github.com/cloudfoundry/binary-builder/pull/81/files and possibly causing the `uninitialized constant HwcRecipe (NameError)` error in https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/build-node-22.x.x/builds/21#L669776a0:542