### PR TITLE
fs4: remove --force when gem installing bundler

### DIFF
--- a/cflinuxfs4/bin/binary-builder
+++ b/cflinuxfs4/bin/binary-builder
@@ -5,7 +5,7 @@
 export DEBIAN_DISABLE_RUBYGEMS_INTEGRATION=foo
 
 gem update --system --no-document -q --silent > /dev/null
-gem install bundler --no-document -f -q --silent > /dev/null
+gem install bundler --no-document -q --silent > /dev/null
 bundle config mirror.https://rubygems.org ${RUBYGEM_MIRROR}
 bundle config set --local without 'local'
 bundle install


### PR DESCRIPTION

Node build is throwing the following error (https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/build-node-20.x.x/builds/44) and I don't know why we need "--force":

```
/usr/lib/ruby/vendor_ruby/rubygems/resolver/conflict.rb:47:in `conflicting_dependencies': undefined method `request' for nil:NilClass (NoMethodError)
	from /usr/lib/ruby/vendor_ruby/rubygems/exceptions.rb:61:in `conflicting_dependencies'
	from /usr/lib/ruby/vendor_ruby/rubygems/exceptions.rb:55:in `initialize'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:193:in `exception'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:193:in `raise'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:193:in `rescue in resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:191:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:411:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:423:in `resolve_current'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:230:in `finish_resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:287:in `block in activate_bin_path'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:285:in `synchronize'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:285:in `activate_bin_path'
	from /usr/bin/bundle:25:in `<main>'
/usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:317:in `raise_error_unless_state': Unable to satisfy the following requirements: (Gem::Resolver::Molinillo::VersionConflict)

- `bundler (= 2.6.3)` required by `user-specified dependency`
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:299:in `block in unwind_for_conflict'
	from <internal:kernel>:90:in `tap'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:297:in `unwind_for_conflict'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:682:in `attempt_to_activate'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:254:in `process_topmost_state'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:182:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolver.rb:43:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:190:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:411:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:423:in `resolve_current'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:230:in `finish_resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:287:in `block in activate_bin_path'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:285:in `synchronize'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:285:in `activate_bin_path'
	from /usr/bin/bundle:25:in `<main>'
/usr/lib/ruby/vendor_ruby/rubygems/resolver/conflict.rb:47:in `conflicting_dependencies': undefined method `request' for nil:NilClass (NoMethodError)
	from /usr/lib/ruby/vendor_ruby/rubygems/exceptions.rb:61:in `conflicting_dependencies'
	from /usr/lib/ruby/vendor_ruby/rubygems/exceptions.rb:55:in `initialize'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:193:in `exception'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:193:in `raise'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:193:in `rescue in resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:191:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:411:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:423:in `resolve_current'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:230:in `finish_resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:287:in `block in activate_bin_path'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:285:in `synchronize'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:285:in `activate_bin_path'
	from /usr/bin/bundle:25:in `<main>'
/usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:317:in `raise_error_unless_state': Unable to satisfy the following requirements: (Gem::Resolver::Molinillo::VersionConflict)

- `bundler (= 2.6.3)` required by `user-specified dependency`
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:299:in `block in unwind_for_conflict'
	from <internal:kernel>:90:in `tap'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:297:in `unwind_for_conflict'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:682:in `attempt_to_activate'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:254:in `process_topmost_state'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:182:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolver.rb:43:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:190:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:411:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:423:in `resolve_current'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:230:in `finish_resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:287:in `block in activate_bin_path'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:285:in `synchronize'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:285:in `activate_bin_path'
	from /usr/bin/bundle:25:in `<main>'
/usr/lib/ruby/vendor_ruby/rubygems/resolver/conflict.rb:47:in `conflicting_dependencies': undefined method `request' for nil:NilClass (NoMethodError)
	from /usr/lib/ruby/vendor_ruby/rubygems/exceptions.rb:61:in `conflicting_dependencies'
	from /usr/lib/ruby/vendor_ruby/rubygems/exceptions.rb:55:in `initialize'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:193:in `exception'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:193:in `raise'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:193:in `rescue in resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:191:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:411:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:423:in `resolve_current'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:230:in `finish_resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:287:in `block in activate_bin_path'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:285:in `synchronize'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:285:in `activate_bin_path'
	from /usr/bin/bundle:25:in `<main>'
/usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:317:in `raise_error_unless_state': Unable to satisfy the following requirements: (Gem::Resolver::Molinillo::VersionConflict)

- `bundler (= 2.6.3)` required by `user-specified dependency`
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:299:in `block in unwind_for_conflict'
	from <internal:kernel>:90:in `tap'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:297:in `unwind_for_conflict'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:682:in `attempt_to_activate'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:254:in `process_topmost_state'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:182:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolver.rb:43:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:190:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:411:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:423:in `resolve_current'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:230:in `finish_resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:287:in `block in activate_bin_path'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:285:in `synchronize'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:285:in `activate_bin_path'
	from /usr/bin/bundle:25:in `<main>'
/usr/lib/ruby/vendor_ruby/rubygems/resolver/conflict.rb:47:in `conflicting_dependencies': undefined method `request' for nil:NilClass (NoMethodError)
	from /usr/lib/ruby/vendor_ruby/rubygems/exceptions.rb:61:in `conflicting_dependencies'
	from /usr/lib/ruby/vendor_ruby/rubygems/exceptions.rb:55:in `initialize'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:193:in `exception'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:193:in `raise'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:193:in `rescue in resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:191:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:411:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:423:in `resolve_current'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:230:in `finish_resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:287:in `block in activate_bin_path'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:285:in `synchronize'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:285:in `activate_bin_path'
	from /usr/bin/bundle:25:in `<main>'
/usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:317:in `raise_error_unless_state': Unable to satisfy the following requirements: (Gem::Resolver::Molinillo::VersionConflict)

- `bundler (= 2.6.3)` required by `user-specified dependency`
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:299:in `block in unwind_for_conflict'
	from <internal:kernel>:90:in `tap'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:297:in `unwind_for_conflict'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:682:in `attempt_to_activate'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:254:in `process_topmost_state'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:182:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver/molinillo/lib/molinillo/resolver.rb:43:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/resolver.rb:190:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:411:in `resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems/request_set.rb:423:in `resolve_current'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:230:in `finish_resolve'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:287:in `block in activate_bin_path'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:285:in `synchronize'
	from /usr/lib/ruby/vendor_ruby/rubygems.rb:285:in `activate_bin_path'
	from /usr/bin/bundle:25:in `<main>'
/tmp/build/c71fb8d0/buildpacks-ci/tasks/build-binary-new-cflinuxfs4/builder.rb:91:in `run': Could not run ["./bin/binary-builder", "--name=node", "--version=20.18.2", "--sha256=cf3ef49fafbfee3cdcd936a0d6031341b73bfa6b26a484ea0a4936c26d24b829"] (RuntimeError)
	from /tmp/build/c71fb8d0/buildpacks-ci/tasks/build-binary-new-cflinuxfs4/binary_builder_wrapper.rb:22:in `block in build'
	from /tmp/build/c71fb8d0/buildpacks-ci/tasks/build-binary-new-cflinuxfs4/binary_builder_wrapper.rb:18:in `chdir'
	from /tmp/build/c71fb8d0/buildpacks-ci/tasks/build-binary-new-cflinuxfs4/binary_builder_wrapper.rb:18:in `build'
	from /tmp/build/c71fb8d0/buildpacks-ci/tasks/build-binary-new-cflinuxfs4/builder.rb:525:in `build_node'
	from /tmp/build/c71fb8d0/buildpacks-ci/tasks/build-binary-new-cflinuxfs4/builder.rb:296:in `public_send'
	from /tmp/build/c71fb8d0/buildpacks-ci/tasks/build-binary-new-cflinuxfs4/builder.rb:296:in `build'
	from /tmp/build/c71fb8d0/buildpacks-ci/tasks/build-binary-new-cflinuxfs4/builder.rb:880:in `execute'
	from buildpacks-ci/tasks/build-binary-new-cflinuxfs4/build.rb:24:in `main'
	from buildpacks-ci/tasks/build-binary-new-cflinuxfs4/build.rb:38:in `<main>'
```