### PR TITLE
libsodium: try alt url to bypass concourse access issues

### DIFF
--- a/cflinuxfs4/recipe/php_common_recipes.rb
+++ b/cflinuxfs4/recipe/php_common_recipes.rb
@@ -137,7 +137,7 @@ end
 
 class LibSodiumRecipe < PkgConfigLibRecipe
   def url
-    "https://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz"
+    "https://github.com/jedisct1/libsodium/archive/#{version}-RELEASE.tar.gz"
   end
 
   def pkgcfg_name

--- a/recipe/php_common_recipes.rb
+++ b/recipe/php_common_recipes.rb
@@ -111,7 +111,7 @@ end
 
 class LibSodiumRecipe < PkgConfigLibRecipe
   def url
-    "https://download.libsodium.org/libsodium/releases/libsodium-#{version}.tar.gz"
+    "https://github.com/jedisct1/libsodium/archive/#{version}-RELEASE.tar.gz"
   end
 
   def pkgcfg_name


### PR DESCRIPTION
Also see https://github.com/cloudfoundry/buildpacks-ci/pull/428