### PR TITLE
hwc: fix arch mismatch

### DIFF
--- a/recipe/hwc.rb
+++ b/recipe/hwc.rb
@@ -32,8 +32,8 @@ class HwcRecipe < BaseRecipe
       ) or raise 'Could not build hwc 386'
     end
 
-    FileUtils.mv("#{tmp_path}/hwc/hwc-windows-386", '/tmp/hwc.exe')
-    FileUtils.mv("#{tmp_path}/hwc/hwc-windows-amd64", '/tmp/hwc_x86.exe')
+    FileUtils.mv("#{tmp_path}/hwc/hwc-windows-amd64", '/tmp/hwc.exe')
+    FileUtils.mv("#{tmp_path}/hwc/hwc-windows-386", '/tmp/hwc_x86.exe')
   end
 
   def archive_files


### PR DESCRIPTION
Looks like in #81, the 64 bit binary was assigned to hwc_x86.exe in error and vice versa. See https://github.com/cloudfoundry/hwc-buildpack/blob/master/bin/release.bat

Addresses https://github.com/cloudfoundry/hwc-buildpack/issues/240