### PR TITLE
Increase make parallelism to use all CPU cores

### DIFF
--- a/cflinuxfs4/recipe/base.rb
+++ b/cflinuxfs4/recipe/base.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'mini_portile2'
+require 'etc'
 require 'tmpdir'
 require 'fileutils'
 require_relative 'determine_checksum'
@@ -24,7 +25,7 @@ class BaseRecipe < MiniPortile
   end
 
   def compile
-    execute('compile', [make_cmd, '-j4'])
+    execute('compile', [make_cmd, "-j#{Etc.nprocessors}"])
   end
 
   def archive_filename

--- a/recipe/base.rb
+++ b/recipe/base.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require 'mini_portile'
 require 'net/ftp'
+require 'etc'
 require 'tmpdir'
 require 'fileutils'
 require_relative 'determine_checksum'
@@ -24,7 +25,7 @@ class BaseRecipe < MiniPortile
   end
 
   def compile
-    execute('compile', [make_cmd, '-j4'])
+    execute('compile', [make_cmd, "-j#{Etc.nprocessors}"])
   end
 
   def archive_filename

--- a/recipe/python.rb
+++ b/recipe/python.rb
@@ -58,7 +58,7 @@ class PythonRecipe < BaseRecipe
 
   def install_apt(packages)
     STDOUT.print "Running 'install dependencies' for #{@name} #{@version}... "
-    if run("sudo apt-get update && sudo apt-get -y install #{packages}")
+    if run("apt-get update && apt-get -y install #{packages}")
       STDOUT.puts "OK"
     else
       raise "Failed to complete install dependencies task"


### PR DESCRIPTION
## Summary
- Changes `make -j4` to `make -j$(nproc)` to use all available CPU cores instead of hardcoded 4 jobs
- Removes unnecessary `sudo` from apt-get commands in python recipe (build containers run as root)

## Motivation
This significantly reduces compilation time for large dependencies like Node.js:
- Before: ~1h15m with `-j4` on typical CI workers (4-12 cores)
- After: ~30m with `-j$(nproc)` on 12-core workers
- Reduces exposure to worker infrastructure failures during long builds

## Testing
Part of fix for Node.js LTS build failures in buildpacks-ci `dependency-builds` pipeline (builds #29-#33).

Changes apply to both cflinuxfs4 and legacy recipe paths.

## Related
- buildpacks-ci PR: https://github.com/cloudfoundry/buildpacks-ci (branch: simple-cflunuxfs5-adoption)
- Fixes worker timeout issues in `build-node-node-lts` Concourse job