### PR TITLE
fix: RubygemsRecipe returns Stack: "any-stack" to produce correct artifact URLs

### DIFF
--- a/internal/recipe/recipe_test.go
+++ b/internal/recipe/recipe_test.go
@@ -470,6 +470,7 @@ func TestRubygemsRecipeNameAndArtifact(t *testing.T) {
 	r := &recipe.RubygemsRecipe{}
 	assert.Equal(t, "rubygems", r.Name())
 	assert.Equal(t, "noarch", r.Artifact().Arch)
+	assert.Equal(t, "any-stack", r.Artifact().Stack)
 }
 
 // ── MinicondaRecipe ───────────────────────────────────────────────────────────

--- a/internal/recipe/simple.go
+++ b/internal/recipe/simple.go
@@ -90,7 +90,7 @@ type RubygemsRecipe struct {
 
 func (rg *RubygemsRecipe) Name() string { return "rubygems" }
 func (rg *RubygemsRecipe) Artifact() ArtifactMeta {
-	return ArtifactMeta{OS: "linux", Arch: "noarch", Stack: ""}
+	return ArtifactMeta{OS: "linux", Arch: "noarch", Stack: "any-stack"}
 }
 func (rg *RubygemsRecipe) Build(ctx context.Context, s *stack.Stack, src *source.Input, r runner.Runner, out *output.OutData) error {
 	return (&RepackRecipe{


### PR DESCRIPTION
## Summary

- Fix `RubygemsRecipe.Artifact()` to return `Stack: "any-stack"` instead of `""`, matching the pattern used by `MinicondaRecipe` and `HWCRecipe`
- Add Stack assertion to `TestRubygemsRecipeNameAndArtifact`

## Problem

When `Stack` is empty, `finalizeArtifact()` in `cmd/binary-builder/main.go` falls back to the `--stack` CLI flag value (e.g., `cflinuxfs4`), producing artifact URLs like:

```
rubygems_4.0.9_linux_noarch_cflinuxfs4_64a69641.tgz
```

instead of the expected:

```
rubygems_4.0.9_linux_noarch_any-stack_64a69641.tgz
```

This breaks the downstream update pipeline in `buildpacks-ci`:

1. `Dependencies.any_stack_dep?` checks `uri.include?('any-stack')` → returns `false`
2. `same_dependency_line?` fails to match the old rubygems entry
3. Manifest ends up with duplicate rubygems versions per stack
4. Ruby buildpack's `UpdateRubygems()` errors: `"Too many versions of rubygems in manifest"`

## Fix

One-line change in `internal/recipe/simple.go:93`:

```go
// Before
return ArtifactMeta{OS: "linux", Arch: "noarch", Stack: ""}
// After
return ArtifactMeta{OS: "linux", Arch: "noarch", Stack: "any-stack"}
```

## Testing

```
$ go test ./internal/recipe/... -run TestRubygems -v
=== RUN   TestRubygemsRecipeDownloads
--- PASS: TestRubygemsRecipeDownloads
=== RUN   TestRubygemsRecipeNameAndArtifact
--- PASS: TestRubygemsRecipeNameAndArtifact
PASS
```

Full recipe test suite also passes.

## Follow-up

After merge, re-trigger `build-rubygems-latest` then `update-rubygems-latest-ruby` in the `dependency-builds` Concourse pipeline to generate a correct ruby-buildpack PR.