### PR TITLE
Fix missing libhashkit.so in PHP tarball for cflinuxfs5

### DIFF
--- a/internal/recipe/php.go
+++ b/internal/recipe/php.go
@@ -223,6 +223,7 @@ func (p *PHPRecipe) setupTar(ec php.ExtensionContext, run runner.Runner) error {
 		fmt.Sprintf("cp -a %s/libaspell.so* %s/lib", libDir, phpPath),
 		fmt.Sprintf("cp -a %s/libpspell.so* %s/lib", libDir, phpPath),
 		fmt.Sprintf("cp -a %s/libmemcached.so* %s/lib/", libDir, phpPath),
+		fmt.Sprintf("cp -a %s/libhashkit.so* %s/lib/", libDir, phpPath),
 		fmt.Sprintf("cp -a %s/libuv.so* %s/lib", libDir, phpPath),
 		fmt.Sprintf("cp -a %s/libargon2.so* %s/lib", libDir, phpPath),
 		fmt.Sprintf("cp -a /usr/lib/librdkafka.so* %s/lib/", phpPath),


### PR DESCRIPTION
## Problem

On Ubuntu 24.04 (cflinuxfs5), the `libmemcached` package was split: `libmemcached.so.11` now dynamically links against `libhashkit.so.2` (shipped as the separate `libhashkit2t64` package). On Ubuntu 22.04 (cflinuxfs4) `libhashkit` was statically linked into `libmemcached.so.11`, so this dependency was invisible.

`setupTar()` was already copying `libmemcached.so*` into the PHP tarball but omitted `libhashkit.so*`, causing `memcached.so` to fail at runtime on cflinuxfs5:

```
PHP Startup: Unable to load dynamic library 'memcached.so'
(libhashkit.so.2: cannot open shared object file: No such file or directory)
```

This manifested as a Composer failure in the php-buildpack integration tests (cflinuxfs5 only):

```
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - Root composer.json requires PHP extension ext-memcached * but it is missing from your system.
```

## Fix

Copy `libhashkit.so*` alongside `libmemcached.so*` in `setupTar()` — a single unconditional line, no stack-specific branching needed.

`libhashkit.so.2` is present on both stacks (`libhashkit-dev` is pulled in transitively by `libmemcached-dev` on Ubuntu 22.04 as well), so the copy is safe for cflinuxfs4 builds too.

## Testing

- `go test ./internal/recipe/...` passes
- PHP tarballs for cflinuxfs5 need to be rebuilt after this lands for the fix to take effect in the buildpack CI