### PR TITLE
fix: bump bootstrap Go from 1.24.2 to 1.25.9

### DIFF
--- a/stacks/cflinuxfs4.yaml
+++ b/stacks/cflinuxfs4.yaml
@@ -93,8 +93,8 @@ apt_packages:
 
 bootstrap:
   go:
-    url: https://go.dev/dl/go1.24.2.linux-amd64.tar.gz
-    sha256: 68097bd680839cbc9d464a0edce4f7c333975e27a90246890e9f1078c7e702ad
+    url: https://go.dev/dl/go1.25.9.linux-amd64.tar.gz
+    sha256: 00859d7bd6defe8bf84d9db9e57b9a4467b2887c18cd93ae7460e713db774bc1
   jruby:
     url: https://java-buildpack.cloudfoundry.org/openjdk-jdk/jammy/x86_64/bellsoft-jdk8u452%2B11-linux-amd64.tar.gz
     sha256: d87d70d286150e662f12650ed22d91f1663c267b27ab3b0775eed1416ef3bd12

--- a/stacks/cflinuxfs5.yaml
+++ b/stacks/cflinuxfs5.yaml
@@ -91,8 +91,8 @@ apt_packages:
 
 bootstrap:
   go:
-    url: https://go.dev/dl/go1.24.2.linux-amd64.tar.gz
-    sha256: 68097bd680839cbc9d464a0edce4f7c333975e27a90246890e9f1078c7e702ad
+    url: https://go.dev/dl/go1.25.9.linux-amd64.tar.gz
+    sha256: 00859d7bd6defe8bf84d9db9e57b9a4467b2887c18cd93ae7460e713db774bc1
   jruby:
     url: https://java-buildpack.cloudfoundry.org/openjdk-jdk/jammy/x86_64/bellsoft-jdk8u452%2B11-linux-amd64.tar.gz
     sha256: d87d70d286150e662f12650ed22d91f1663c267b27ab3b0775eed1416ef3bd12


### PR DESCRIPTION
## Summary

- Bumps bootstrap Go toolchain from go1.24.2 to go1.25.9 (latest stable 1.25.x) in both cflinuxfs4 and cflinuxfs5 stack configs
- Fixes `build-go-1.26.x` pipeline failure: `go tool dist: go1.24.2 does not meet the minimum bootstrap requirement of go1.24.6 or later`
- go1.24.x is EOL; go1.25.9 satisfies current and future Go bootstrap requirements