### PR TITLE
Bump APCu to 5.1.28 and yaf to 3.3.7; clean up version-specific patches

### DIFF
--- a/internal/php/assets/php8-base-extensions.yml
+++ b/internal/php/assets/php8-base-extensions.yml
@@ -26,8 +26,8 @@ native_modules:
   klass: LibSodiumRecipe
 extensions:
 - name: apcu
-  version: 5.1.23
-  md5: c6ed350a587cf2b376c1efeb31f68907
+  version: 5.1.28
+  md5: 69e2063b28725aca0ce6cac087a5d2bc
   klass: PeclRecipe
 - name: igbinary
   version: 3.2.15

--- a/internal/php/assets/php8-base-extensions.yml
+++ b/internal/php/assets/php8-base-extensions.yml
@@ -98,8 +98,8 @@ extensions:
   md5: 3c5bca14b7c638893383646565d78e9b
   klass: PeclRecipe
 - name: yaf
-  version: 3.3.5
-  md5: 128ecf6c84dd71d59c12d826cc51f0c4
+  version: 3.3.7
+  md5: 8c97aa7e81c5592c7bddae1b8a0cff50
   klass: PeclRecipe
 - name: yaml
   version: 2.2.3

--- a/internal/php/assets/php82-extensions-patch.yml
+++ b/internal/php/assets/php82-extensions-patch.yml
@@ -1,10 +1,5 @@
 ---
 extensions:
-  exclusions:
-    - name: yaf
-      version: 3.3.5
-      md5: 128ecf6c84dd71d59c12d826cc51f0c4
-      klass: PeclRecipe
   additions:
     - name: oci8
       version: 3.3.0

--- a/internal/php/assets/php83-extensions-patch.yml
+++ b/internal/php/assets/php83-extensions-patch.yml
@@ -1,10 +1,5 @@
 ---
 extensions:
-  exclusions:
-    - name: yaf
-      version: 3.3.5
-      md5: 128ecf6c84dd71d59c12d826cc51f0c4
-      klass: PeclRecipe
   additions:
     - name: ioncube
       version: 14.0.0

--- a/internal/php/assets/php84-extensions-patch.yml
+++ b/internal/php/assets/php84-extensions-patch.yml
@@ -36,15 +36,6 @@ extensions:
       md5: 3e9df94b06f8a026e33b3a8a3f02921b
       klass: PeclRecipe
   additions:
-    - name: apcu
-      version: 5.1.24
-      md5: 65494e2af7c92bdef075030b9d9e2da4
-      klass: PeclRecipe
-    # yaf 3.3.6 calls php_pcre_match_impl with wrong arg count on PHP 8.4; replaced by 3.3.7
-    - name: yaf
-      version: 3.3.7
-      md5: 8c97aa7e81c5592c7bddae1b8a0cff50
-      klass: PeclRecipe
     - name: ioncube
       version: 15.5.0
       md5: nil

--- a/internal/php/assets/php84-extensions-patch.yml
+++ b/internal/php/assets/php84-extensions-patch.yml
@@ -1,14 +1,6 @@
 ---
 extensions:
   exclusions:
-    - name: apcu
-      version: 5.1.23
-      md5: c6ed350a587cf2b376c1efeb31f68907
-      klass: PeclRecipe
-    - name: yaf
-      version: 3.3.5
-      md5: 128ecf6c84dd71d59c12d826cc51f0c4
-      klass: PeclRecipe
     - name: mongodb
       version: 1.18.1
       md5: 8939b5f966fa3ba6bb8e25206b9dae0f

--- a/internal/php/assets/php85-extensions-patch.yml
+++ b/internal/php/assets/php85-extensions-patch.yml
@@ -1,14 +1,6 @@
 ---
 extensions:
   exclusions:
-    - name: apcu
-      version: 5.1.23
-      md5: c6ed350a587cf2b376c1efeb31f68907
-      klass: PeclRecipe
-    - name: yaf
-      version: 3.3.5
-      md5: 128ecf6c84dd71d59c12d826cc51f0c4
-      klass: PeclRecipe
     - name: mongodb
       version: 1.18.1
       md5: 8939b5f966fa3ba6bb8e25206b9dae0f
@@ -94,14 +86,6 @@ extensions:
       md5: c48f5de2f96ffebe2e18eaefff4917f9
       klass: PeclRecipe
   additions:
-    - name: apcu
-      version: 5.1.24
-      md5: 65494e2af7c92bdef075030b9d9e2da4
-      klass: PeclRecipe
-    - name: yaf
-      version: 3.3.7
-      md5: 8c97aa7e81c5592c7bddae1b8a0cff50
-      klass: PeclRecipe
     - name: ioncube
       version: 15.5.0
       md5: nil


### PR DESCRIPTION
**APCu 5.1.23 → 5.1.28**
APCu 5.1.23 has a `config.m4` bug where `APCU_CFLAGS=` is parsed as a shell command, causing -`DZEND_COMPILE_DL_EXT=1` (with quotes) to be passed as a linker input filename on PHP 8.4+, breaking the build. This has been fixed in 5.1.24+. 5.1.28 is the latest stable release and is compatible with PHP 8.2–8.5.

**yaf 3.3.5 → 3.3.7**
yaf 3.3.5 does not build on PHP 8.3+ (fixed in 3.3.6). yaf 3.3.6 calls `php_pcre_match_impl` with too many arguments on PHP 8.4 — the function signature changed in PHP 8.4 (fixed in 3.3.7). yaf 3.3.7 is compatible with PHP 8.2–8.5.

**Patch cleanup**
Since both versions now work across all supported PHP 8.x lines, the per-version patch entries (exclusions of old versions and additions of intermediate versions) are removed from `php82`, `php83`, `php84`, and `php85` patch files.

**Fixes**: build-php-8.4.x and build-php-8.5.x dependency pipeline failures.