### PR TITLE
feat: add PHP 8.4 and PHP 8.5 extension patch support

### DIFF
--- a/internal/php/assets/php84-extensions-patch.yml
+++ b/internal/php/assets/php84-extensions-patch.yml
@@ -1,0 +1,84 @@
+---
+extensions:
+  exclusions:
+    - name: apcu
+      version: 5.1.23
+      md5: c6ed350a587cf2b376c1efeb31f68907
+      klass: PeclRecipe
+    - name: yaf
+      version: 3.3.5
+      md5: 128ecf6c84dd71d59c12d826cc51f0c4
+      klass: PeclRecipe
+    - name: mongodb
+      version: 1.18.1
+      md5: 8939b5f966fa3ba6bb8e25206b9dae0f
+      klass: PeclRecipe
+    # oauth 2.0.7 uses php_rand.h which was removed in PHP 8.4; replaced by 2.0.10
+    - name: oauth
+      version: 2.0.7
+      md5: 8ea6eb5ac6de8a4ed399980848c04c0c
+      klass: PeclRecipe
+    # redis 6.0.2 uses standard/php_random.h which was removed in PHP 8.4; replaced by 6.1.0
+    - name: redis
+      version: 6.0.2
+      md5: 29f1f0ba367aef7e0313cd75aa1ea83f
+      klass: PeclRecipe
+    # xdebug 3.3.2 does not support PHP >= 8.4; replaced by 3.4.0
+    - name: xdebug
+      version: 3.3.2
+      md5: 3c5bca14b7c638893383646565d78e9b
+      klass: PeclRecipe
+    # phalcon 5.6.2 uses php_rand.h which was removed in PHP 8.4; no compatible PECL release exists
+    - name: phalcon
+      version: 5.6.2
+      md5: 806c25f017c0842798d937caaecbc994
+      klass: PeclRecipe
+    # tideways_xhprof 5.0.4 has configure syntax error on PHP 8.4; no newer release available
+    - name: tideways_xhprof
+      version: 5.0.4
+      md5: 68b68cd9410e62b8481445e0d89220c0
+      klass: TidewaysXhprofRecipe
+    # solr 2.7.0 has configure syntax error on PHP 8.4; replaced by 2.9.3
+    - name: solr
+      version: 2.7.0
+      md5: 3e9df94b06f8a026e33b3a8a3f02921b
+      klass: PeclRecipe
+  additions:
+    - name: apcu
+      version: 5.1.24
+      md5: 65494e2af7c92bdef075030b9d9e2da4
+      klass: PeclRecipe
+    - name: yaf
+      version: 3.3.6
+      md5: 851d029b28e71d4b43b5d1a41a536c40
+      klass: PeclRecipe
+    - name: ioncube
+      version: 15.5.0
+      md5: nil
+      klass: IonCubeRecipe
+    - name: mongodb
+      version: 2.2.1
+      md5: 40b977a2d22c41958d57d31f8e4d44da
+      klass: PeclRecipe
+    # oauth 2.0.10 adds PHP 8.4 support (php_rand.h conditional)
+    - name: oauth
+      version: 2.0.10
+      md5: 47eeb6adc46a72844f48ce7d2ad3f0da
+      klass: PeclRecipe
+    # redis 6.1.0 adds PHP 8.4 support (fixes php_random.h includes)
+    - name: redis
+      version: 6.1.0
+      md5: ca6277b27ee35e1f55f9ad7f0b4df29b
+      klass: PeclRecipe
+    # xdebug 3.4.0 adds PHP 8.4 support
+    - name: xdebug
+      version: 3.4.0
+      md5: 799983a15e5f5ec7fb19d70304415128
+      klass: PeclRecipe
+    # phalcon has no PHP 8.4 compatible PECL release (all versions use removed php_rand.h)
+    # tideways_xhprof has no PHP 8.4 compatible release (configure syntax error, no newer version)
+    # solr 2.9.3 adds PHP 8.4 support (configure.ac rewritten)
+    - name: solr
+      version: 2.9.3
+      md5: ec442fc69a885220345d13d0889b10e5
+      klass: PeclRecipe

--- a/internal/php/assets/php85-extensions-patch.yml
+++ b/internal/php/assets/php85-extensions-patch.yml
@@ -1,0 +1,180 @@
+---
+extensions:
+  exclusions:
+    - name: apcu
+      version: 5.1.23
+      md5: c6ed350a587cf2b376c1efeb31f68907
+      klass: PeclRecipe
+    - name: yaf
+      version: 3.3.5
+      md5: 128ecf6c84dd71d59c12d826cc51f0c4
+      klass: PeclRecipe
+    - name: mongodb
+      version: 1.18.1
+      md5: 8939b5f966fa3ba6bb8e25206b9dae0f
+      klass: PeclRecipe
+    # oauth 2.0.7 uses php_rand.h which was removed in PHP 8.4+; replaced by 2.0.10
+    - name: oauth
+      version: 2.0.7
+      md5: 8ea6eb5ac6de8a4ed399980848c04c0c
+      klass: PeclRecipe
+    # redis 6.0.2 uses standard/php_random.h which was removed in PHP 8.4+; replaced by 6.1.0
+    - name: redis
+      version: 6.0.2
+      md5: 29f1f0ba367aef7e0313cd75aa1ea83f
+      klass: PeclRecipe
+    # xdebug 3.3.2 does not support PHP >= 8.5; replaced by 3.5.1
+    - name: xdebug
+      version: 3.3.2
+      md5: 3c5bca14b7c638893383646565d78e9b
+      klass: PeclRecipe
+    # phalcon 5.6.2 uses php_rand.h which was removed in PHP 8.4+; no compatible PECL release exists
+    - name: phalcon
+      version: 5.6.2
+      md5: 806c25f017c0842798d937caaecbc994
+      klass: PeclRecipe
+    # tideways_xhprof 5.0.4 has configure syntax error on PHP 8.4+; no newer release available
+    - name: tideways_xhprof
+      version: 5.0.4
+      md5: 68b68cd9410e62b8481445e0d89220c0
+      klass: TidewaysXhprofRecipe
+    # memcached 3.2.0 has unguarded php_smart_string.h removed in PHP 8.5; replaced by 3.4.0
+    - name: memcached
+      version: 3.2.0
+      md5: acc58fea7b7f456408a25ac927846ad0
+      klass: MemcachedPeclRecipe
+    # amqp 2.1.2 uses unguarded zend_exception_get_default() removed in PHP 8.5; replaced by 2.2.0
+    - name: amqp
+      version: 2.1.2
+      md5: addd05de32a74af7d3d332b5f58b8414
+      klass: AmqpPeclRecipe
+    # stomp 2.0.3 uses unguarded zend_exception_get_default() removed in PHP 8.5; no fix available
+    - name: stomp
+      version: 2.0.3
+      md5: 30de4089ae5c17f32617cef35dbe53e5
+      klass: PeclRecipe
+    # solr 2.7.0 has configure syntax error on PHP 8.4+; replaced by 2.9.3
+    - name: solr
+      version: 2.7.0
+      md5: 3e9df94b06f8a026e33b3a8a3f02921b
+      klass: PeclRecipe
+    # igbinary 3.2.15 uses php_smart_string.h which was removed in PHP 8.5; replaced by 3.2.17RC1
+    - name: igbinary
+      version: 3.2.15
+      md5: de81e2f54bfbe741a7f2453bccf970e9
+      klass: PeclRecipe
+    # imagick 3.7.0 uses php_smart_string.h which was removed in PHP 8.5; replaced by 3.8.1
+    - name: imagick
+      version: 3.7.0
+      md5: 0687774a6126467d4e5ede02171e981d
+      klass: PeclRecipe
+    # mailparse 3.1.6 uses php_smart_string.h which was removed in PHP 8.5; replaced by 3.2.0
+    - name: mailparse
+      version: 3.1.6
+      md5: e3a71b27439ee08dd63272d7d290d136
+      klass: PeclRecipe
+    # pdo_sqlsrv 5.12.0 has PHP 8.5 struct incompatibilities; replaced by 5.13.0
+    - name: pdo_sqlsrv
+      version: 5.12.0
+      md5: 0c06402f30a7f6f0b758ad55277ad950
+      klass: PeclRecipe
+    # sqlsrv 5.12.0 has PHP 8.5 struct incompatibilities; replaced by 5.13.0
+    - name: sqlsrv
+      version: 5.12.0
+      md5: e62485cbbcb564f4a55ab8eae40df6a6
+      klass: PeclRecipe
+    # yaml 2.2.3 unconditionally includes php_smart_string.h removed in PHP 8.5; replaced by 2.3.0
+    - name: yaml
+      version: 2.2.3
+      md5: 8d8d18bc1d033966083ec4d6e993d61a
+      klass: PeclRecipe
+    # gnupg 1.5.1 uses removed zend_exception_get_default(); replaced by 1.5.4
+    - name: gnupg
+      version: 1.5.1
+      md5: c48f5de2f96ffebe2e18eaefff4917f9
+      klass: PeclRecipe
+  additions:
+    - name: apcu
+      version: 5.1.24
+      md5: 65494e2af7c92bdef075030b9d9e2da4
+      klass: PeclRecipe
+    - name: yaf
+      version: 3.3.7
+      md5: 8c97aa7e81c5592c7bddae1b8a0cff50
+      klass: PeclRecipe
+    - name: ioncube
+      version: 15.5.0
+      md5: nil
+      klass: IonCubeRecipe
+    - name: mongodb
+      version: 2.2.1
+      md5: 40b977a2d22c41958d57d31f8e4d44da
+      klass: PeclRecipe
+    # oauth 2.0.10 adds PHP 8.4+ support (php_rand.h conditional)
+    - name: oauth
+      version: 2.0.10
+      md5: 47eeb6adc46a72844f48ce7d2ad3f0da
+      klass: PeclRecipe
+    # redis 6.3.0 adds PHP 8.5 support (removes php_smart_string.h dependency)
+    - name: redis
+      version: 6.3.0
+      md5: ac080d0329813bb1291d0697c6f539c4
+      klass: PeclRecipe
+    # xdebug 3.5.1 adds PHP 8.5 support (< 8.6)
+    - name: xdebug
+      version: 3.5.1
+      md5: d404e827a10ab301d602533d6eb8bceb
+      klass: PeclRecipe
+    # phalcon has no PHP 8.4+ compatible PECL release (all versions use removed php_rand.h)
+    # tideways_xhprof has no PHP 8.4+ compatible release (configure syntax error, no newer version)
+    # stomp has no PHP 8.5 compatible release (unguarded zend_exception_get_default, no newer version)
+    # solr 2.9.3 adds PHP 8.4+ support (configure.ac rewritten)
+    - name: solr
+      version: 2.9.3
+      md5: ec442fc69a885220345d13d0889b10e5
+      klass: PeclRecipe
+    # igbinary 3.2.17RC1 adds PHP 8.5 support (removes php_smart_string.h dependency)
+    - name: igbinary
+      version: 3.2.17RC1
+      md5: 84d49a68917b5ad5cf087ee7286e91ba
+      klass: PeclRecipe
+    # imagick 3.8.1 adds PHP 8.5 support
+    - name: imagick
+      version: 3.8.1
+      md5: aadbb5ad3db484e19bb6ba39aa2cd4a0
+      klass: PeclRecipe
+    # mailparse 3.2.0 adds PHP 8.5 support (removes php_smart_string.h dependency)
+    - name: mailparse
+      version: 3.2.0
+      md5: 26459ec76b2e8d103faad6ed11d1995e
+      klass: PeclRecipe
+    # pdo_sqlsrv 5.13.0 adds PHP 8.5 support
+    - name: pdo_sqlsrv
+      version: 5.13.0
+      md5: 915a36cb0b294e831d5f66786bc01d4b
+      klass: PeclRecipe
+    # sqlsrv 5.13.0 adds PHP 8.5 support
+    - name: sqlsrv
+      version: 5.13.0
+      md5: 6a3957633e53c260ae3a2740adbaa991
+      klass: PeclRecipe
+    # yaml 2.3.0 adds PHP 8.5 support (guards php_smart_string.h for PHP < 7.2 only)
+    - name: yaml
+      version: 2.3.0
+      md5: 1cd70efbdc86c12c30aee95eeb75cc7f
+      klass: PeclRecipe
+    # gnupg 1.5.4 adds PHP 8.5 support (uses zend_ce_exception instead of removed zend_exception_get_default)
+    - name: gnupg
+      version: 1.5.4
+      md5: 23ae146131b9f4238bdd98a53c087fc5
+      klass: PeclRecipe
+    # memcached 3.4.0 adds PHP 8.5 support (php_smart_string.h guarded by PHP_VERSION_ID < 70200)
+    - name: memcached
+      version: 3.4.0
+      md5: 43c53e36ac2ecc2c3c403e5bf225ee1a
+      klass: MemcachedPeclRecipe
+    # amqp 2.2.0 adds PHP 8.5 support (removes unguarded zend_exception_get_default usage)
+    - name: amqp
+      version: 2.2.0
+      md5: 6888bbca9ee741fa6096efa454d5b9b0
+      klass: AmqpPeclRecipe

--- a/internal/php/extensions.go
+++ b/internal/php/extensions.go
@@ -126,9 +126,12 @@ type patchCategory struct {
 // then applies the patch file for the specific minor version if one exists
 // (e.g. "8"+"2" → php82-extensions-patch.yml).
 //
-// Merge rules:
-//   - For each addition: if name already exists → replace; otherwise → append.
-//   - For each exclusion: remove by name.
+// Merge rules (applied by applyPatch):
+//   - Exclusions run first. If an exclusion has a matching addition, the addition
+//     replaces the entry in-place (preserving list position). Otherwise the entry
+//     is removed.
+//   - Remaining additions (no matching exclusion) override by name if present,
+//     or are appended.
 func Load(phpMajor, phpMinor string) (*ExtensionSet, error) {
 	baseData, ok := embeddedBases[phpMajor]
 	if !ok {
@@ -157,24 +160,47 @@ func Load(phpMajor, phpMinor string) (*ExtensionSet, error) {
 	return &set, nil
 }
 
-// applyPatch applies additions (override by name or append) and exclusions
-// (remove by name) from a patch category to a slice of extensions.
+// applyPatch applies exclusions (remove by name) and then additions
+// (override by name or append) from a patch category to a slice of extensions.
+//
+// When an exclusion removes an entry that has a matching addition (same name),
+// the addition is inserted at the original position so that build-order
+// dependencies (e.g. memcached depending on igbinary) are preserved.
+// Additions with no matching exclusion are appended at the end.
 func applyPatch(list *[]Extension, cat *patchCategory) {
 	if cat == nil {
 		return
 	}
 
+	// Build a lookup of additions by name for O(1) access.
+	addByName := make(map[string]Extension, len(cat.Additions))
 	for _, add := range cat.Additions {
+		addByName[add.Name] = add
+	}
+
+	// Apply exclusions. When the excluded name has a corresponding addition,
+	// replace in-place to preserve position; otherwise remove.
+	replaced := make(map[string]bool)
+	for _, excl := range cat.Exclusions {
+		if idx := indexByName(*list, excl.Name); idx >= 0 {
+			if add, ok := addByName[excl.Name]; ok {
+				(*list)[idx] = add
+				replaced[excl.Name] = true
+			} else {
+				*list = append((*list)[:idx], (*list)[idx+1:]...)
+			}
+		}
+	}
+
+	// Apply remaining additions (those not already placed by the exclusion loop).
+	for _, add := range cat.Additions {
+		if replaced[add.Name] {
+			continue
+		}
 		if idx := indexByName(*list, add.Name); idx >= 0 {
 			(*list)[idx] = add
 		} else {
 			*list = append(*list, add)
-		}
-	}
-
-	for _, excl := range cat.Exclusions {
-		if idx := indexByName(*list, excl.Name); idx >= 0 {
-			*list = append((*list)[:idx], (*list)[idx+1:]...)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Add `php84-extensions-patch.yml` and `php85-extensions-patch.yml` with version overrides for PECL extensions incompatible with PHP 8.4+ and 8.5+
- Fix `applyPatch` in `extensions.go` to apply exclusions before additions, and replace excluded entries **in-place** when a matching addition exists — preserving build-order dependencies (e.g. `igbinary` must appear before `memcached`)

## Background

PHP 8.4 removed `php_rand.h` and `standard/php_random.h`. PHP 8.5 additionally removed `php_smart_string.h` and `zend_exception_get_default()`. Several PECL extensions in the base list use these removed symbols and fail to compile without version upgrades or exclusions.

The existing `applyPatch` logic had two bugs:
1. **Order bug**: additions ran before exclusions, so an exclusion would silently remove a just-added replacement
2. **Position bug**: after fixing order, replaced entries were appended to the end instead of inserted at the original position, breaking `memcached` (which requires `igbinary` headers to be configured first)

## PHP 8.4 changes

| Extension | Change | Reason |
|---|---|---|
| `oauth 2.0.7` | → `2.0.10` | `php_rand.h` removed in PHP 8.4 |
| `redis 6.0.2` | → `6.1.0` | `standard/php_random.h` removed in PHP 8.4 |
| `xdebug 3.3.2` | → `3.4.0` | explicitly rejects PHP ≥ 8.4 |
| `solr 2.7.0` | → `2.9.3` | configure syntax error on PHP 8.4 |
| `phalcon 5.6.2` | excluded | no compatible PECL release exists |
| `tideways_xhprof 5.0.4` | excluded | no compatible release exists |

## PHP 8.5 changes

All PHP 8.4 changes plus:

| Extension | Change | Reason |
|---|---|---|
| `redis 6.1.0` | → `6.3.0` | `php_smart_string.h` removed in PHP 8.5 |
| `xdebug 3.4.0` | → `3.5.1` | explicitly rejects PHP ≥ 8.5 |
| `igbinary 3.2.15` | → `3.2.17RC1` | `php_smart_string.h` removed |
| `imagick 3.7.0` | → `3.8.1` | `php_smart_string.h` removed |
| `mailparse 3.1.6` | → `3.2.0` | `php_smart_string.h` removed |
| `yaml 2.2.3` | → `2.3.0` | `php_smart_string.h` removed |
| `gnupg 1.5.1` | → `1.5.4` | `zend_exception_get_default()` removed |
| `pdo_sqlsrv 5.12.0` | → `5.13.0` | struct incompatibilities in PHP 8.5 |
| `sqlsrv 5.12.0` | → `5.13.0` | struct incompatibilities in PHP 8.5 |
| `memcached 3.2.0` | → `3.4.0` | `php_smart_string.h` removed |
| `amqp 2.1.2` | → `2.2.0` | `zend_exception_get_default()` removed |
| `stomp 2.0.3` | excluded | no compatible release exists |

## Testing

Both PHP versions were built successfully inside a `cloudfoundry/cflinuxfs4` Docker container using the Go binary-builder:

- `php_8.4.20_linux_x64_cflinuxfs4_461e91d5.tgz` ✅
- `php_8.5.5_linux_x64_cflinuxfs4_e6ea2ed6.tgz` ✅

All unit tests pass (`go test ./...`).