### PR TITLE
Add java-cfenv passthrough recipe and jar artifact support

### DIFF
--- a/cmd/binary-builder/main.go
+++ b/cmd/binary-builder/main.go
@@ -346,7 +346,7 @@ func buildRegistry() *recipe.Registry {
 // artifact file produced by a recipe. Extensions are tried in priority order.
 func findIntermediateArtifact(name, version string) (string, error) {
 	// Extensions in priority order (matches ArtifactOutput.ext in the old Ruby code).
-	exts := []string{"tgz", "tar.gz", "zip", "tar.xz", "tar.bz2", "sh", "phar", "txt"}
+	exts := []string{"tgz", "tar.gz", "zip", "tar.xz", "tar.bz2", "sh", "phar", "jar", "txt"}
 
 	// Recipes that cannot write to CWD (e.g. pip, pipenv) write to os.TempDir.
 	searchDirs := []string{".", os.TempDir()}

--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -81,6 +81,7 @@ func ExtFromPath(path string) string {
 		{".tar.bz2", "tar.bz2"},
 		{".zip", "zip"},
 		{".phar", "phar"},
+		{".jar", "jar"},
 		{".sh", "sh"},
 		{".txt", "txt"},
 	}

--- a/internal/recipe/passthrough.go
+++ b/internal/recipe/passthrough.go
@@ -67,7 +67,7 @@ func NewPassthroughRecipes(f fetch.Fetcher) []Recipe {
 	return []Recipe{
 		&PassthroughRecipe{
 			DepName:            "java-cfenv",
-			SourceFilenameFunc: func(v string) string { return fmt.Sprintf("java-cfenv-boot-%s.jar", v) },
+			SourceFilenameFunc: func(v string) string { return fmt.Sprintf("java-cfenv-%s.jar", v) },
 			Meta:               ArtifactMeta{OS: "linux", Arch: "noarch", Stack: "any-stack"},
 			Fetcher:            f,
 		},

--- a/internal/recipe/passthrough.go
+++ b/internal/recipe/passthrough.go
@@ -66,6 +66,12 @@ func (p *PassthroughRecipe) Build(ctx context.Context, _ *stack.Stack, src *sour
 func NewPassthroughRecipes(f fetch.Fetcher) []Recipe {
 	return []Recipe{
 		&PassthroughRecipe{
+			DepName:            "java-cfenv",
+			SourceFilenameFunc: func(v string) string { return fmt.Sprintf("java-cfenv-boot-%s.jar", v) },
+			Meta:               ArtifactMeta{OS: "linux", Arch: "noarch", Stack: "any-stack"},
+			Fetcher:            f,
+		},
+		&PassthroughRecipe{
 			DepName:            "tomcat",
 			SourceFilenameFunc: func(v string) string { return fmt.Sprintf("apache-tomcat-%s.tar.gz", v) },
 			Meta:               ArtifactMeta{OS: "linux", Arch: "noarch", Stack: "any-stack"},

--- a/internal/recipe/recipe_test.go
+++ b/internal/recipe/recipe_test.go
@@ -241,6 +241,7 @@ func TestPassthroughSourceFilenames(t *testing.T) {
 		version  string
 		wantFile string
 	}{
+		{"java-cfenv", "3.5.0", "java-cfenv-3.5.0.jar"},
 		{"tomcat", "9.0.85", "apache-tomcat-9.0.85.tar.gz"},
 		{"composer", "2.7.1", "composer.phar"},
 		{"appdynamics", "23.11.0.35198", "appdynamics-php-agent-linux_x64-23.11.0.35198.tar.bz2"},
@@ -293,7 +294,7 @@ func TestPassthroughArtifactMeta(t *testing.T) {
 		recipeMap[rec.Name()] = rec
 	}
 
-	anyStack := []string{"tomcat", "composer", "appdynamics", "appdynamics-java", "skywalking-agent"}
+	anyStack := []string{"java-cfenv", "tomcat", "composer", "appdynamics", "appdynamics-java", "skywalking-agent"}
 	for _, name := range anyStack {
 		t.Run(name+"_any-stack", func(t *testing.T) {
 			rec := recipeMap[name]
@@ -323,6 +324,7 @@ func TestNewPassthroughRecipesContents(t *testing.T) {
 		names[i] = r.Name()
 	}
 	assert.Subset(t, names, []string{
+		"java-cfenv",
 		"tomcat", "composer", "appdynamics", "appdynamics-java",
 		"skywalking-agent", "openjdk", "zulu", "sapmachine",
 		"jprofiler-profiler", "your-kit-profiler",


### PR DESCRIPTION
## Summary

- Adds a \`java-cfenv\` \`PassthroughRecipe\` that downloads \`java-cfenv-boot-{version}.jar\` directly from Maven Central (no compilation needed — it's a pre-built JAR)
- Adds \`"jar"\` to the \`findIntermediateArtifact\` extension list so the artifact file is found after download
- Adds \`{".jar", "jar"}\` to \`ExtFromPath\` so the canonical artifact filename gets the correct \`.jar\` extension

## Context

\`java-cfenv\` is a pre-built JAR published on Maven Central at:
\`https://repo1.maven.org/maven2/io/pivotal/cfenv/java-cfenv-boot/{version}/java-cfenv-boot-{version}.jar\`

The depwatcher \`MavenWatcher\` (\`source_type: maven\`) produces a \`data.json\` with \`src.URL\` pointing directly to the JAR — no build step is needed, making \`PassthroughRecipe\` the right pattern (same as \`tomcat\`, \`openjdk\`, etc.).

## Pairs with

cloudfoundry/buildpacks-ci#623