### PR TITLE
Fix yaf for PHP 8.4: bump from 3.3.6 to 3.3.7

### DIFF
--- a/internal/php/assets/php84-extensions-patch.yml
+++ b/internal/php/assets/php84-extensions-patch.yml
@@ -48,9 +48,10 @@ extensions:
       version: 5.1.24
       md5: 65494e2af7c92bdef075030b9d9e2da4
       klass: PeclRecipe
+    # yaf 3.3.6 calls php_pcre_match_impl with wrong arg count on PHP 8.4; replaced by 3.3.7
     - name: yaf
-      version: 3.3.6
-      md5: 851d029b28e71d4b43b5d1a41a536c40
+      version: 3.3.7
+      md5: 8c97aa7e81c5592c7bddae1b8a0cff50
       klass: PeclRecipe
     - name: ioncube
       version: 15.5.0


### PR DESCRIPTION
yaf 3.3.6 calls php_pcre_match_impl with too many arguments on PHP 8.4 (signature changed to remove the extra arg). yaf 3.3.7 fixes this.