### PR TITLE
Add OTEL agent to passthrough recipes

### DIFF
--- a/internal/recipe/passthrough.go
+++ b/internal/recipe/passthrough.go
@@ -72,6 +72,12 @@ func NewPassthroughRecipes(f fetch.Fetcher) []Recipe {
 			Fetcher:            f,
 		},
 		&PassthroughRecipe{
+			DepName:            "open-telemetry-javaagent",
+			SourceFilenameFunc: func(v string) string { return "opentelemetry-javaagent.jar" },
+			Meta:               ArtifactMeta{OS: "linux", Arch: "noarch", Stack: "any-stack"},
+			Fetcher:            f,
+		},
+		&PassthroughRecipe{
 			DepName:            "tomcat",
 			SourceFilenameFunc: func(v string) string { return fmt.Sprintf("apache-tomcat-%s.tar.gz", v) },
 			Meta:               ArtifactMeta{OS: "linux", Arch: "noarch", Stack: "any-stack"},

--- a/internal/recipe/recipe_test.go
+++ b/internal/recipe/recipe_test.go
@@ -241,6 +241,7 @@ func TestPassthroughSourceFilenames(t *testing.T) {
 		version  string
 		wantFile string
 	}{
+	    {"open-telemetry-javaagent", "2.27.0", "opentelemetry-javaagent.jar"},
 		{"java-cfenv", "3.5.0", "java-cfenv-3.5.0.jar"},
 		{"tomcat", "9.0.85", "apache-tomcat-9.0.85.tar.gz"},
 		{"composer", "2.7.1", "composer.phar"},
@@ -294,7 +295,7 @@ func TestPassthroughArtifactMeta(t *testing.T) {
 		recipeMap[rec.Name()] = rec
 	}
 
-	anyStack := []string{"java-cfenv", "tomcat", "composer", "appdynamics", "appdynamics-java", "skywalking-agent"}
+	anyStack := []string{" open-telemetry-javaagent", "java-cfenv", "tomcat", "composer", "appdynamics", "appdynamics-java", "skywalking-agent"}
 	for _, name := range anyStack {
 		t.Run(name+"_any-stack", func(t *testing.T) {
 			rec := recipeMap[name]
@@ -324,7 +325,7 @@ func TestNewPassthroughRecipesContents(t *testing.T) {
 		names[i] = r.Name()
 	}
 	assert.Subset(t, names, []string{
-		"java-cfenv",
+		"open-telemetry-javaagent", "java-cfenv",
 		"tomcat", "composer", "appdynamics", "appdynamics-java",
 		"skywalking-agent", "openjdk", "zulu", "sapmachine",
 		"jprofiler-profiler", "your-kit-profiler",

--- a/internal/recipe/recipe_test.go
+++ b/internal/recipe/recipe_test.go
@@ -295,7 +295,7 @@ func TestPassthroughArtifactMeta(t *testing.T) {
 		recipeMap[rec.Name()] = rec
 	}
 
-	anyStack := []string{" open-telemetry-javaagent", "java-cfenv", "tomcat", "composer", "appdynamics", "appdynamics-java", "skywalking-agent"}
+	anyStack := []string{"open-telemetry-javaagent", "java-cfenv", "tomcat", "composer", "appdynamics", "appdynamics-java", "skywalking-agent"}
 	for _, name := range anyStack {
 		t.Run(name+"_any-stack", func(t *testing.T) {
 			rec := recipeMap[name]


### PR DESCRIPTION
Update the passthrough recipes with regard to `opentelemetry-javaagent`
Linked to https://github.com/cloudfoundry/buildpacks-ci/pull/630