### PR TITLE
Add more java buildpack dependencies to passthrough recipes

### DIFF
--- a/internal/recipe/passthrough.go
+++ b/internal/recipe/passthrough.go
@@ -155,6 +155,30 @@ func NewPassthroughRecipes(f fetch.Fetcher) []Recipe {
 			Meta:               ArtifactMeta{OS: "linux", Arch: "x64", Stack: ""},
 			Fetcher:            f,
 		},
+		&PassthroughRecipe{
+			DepName:            "elastic-apm-agent",
+			SourceFilenameFunc: func(v string) string { return fmt.Sprintf("elastic-apm-agent-%s.jar", v) },
+			Meta:               ArtifactMeta{OS: "linux", Arch: "noarch", Stack: "any-stack"},
+			Fetcher:            f,
+		},
+		&PassthroughRecipe{
+			DepName:            "postgresql-jdbc",
+			SourceFilenameFunc: func(v string) string { return fmt.Sprintf("postgresql-%s.jar", v) },
+			Meta:               ArtifactMeta{OS: "linux", Arch: "noarch", Stack: "any-stack"},
+			Fetcher:            f,
+		},
+		&PassthroughRecipe{
+			DepName:            "mariadb-jdbc",
+			SourceFilenameFunc: func(v string) string { return fmt.Sprintf("mariadb-java-client-%s.jar", v) },
+			Meta:               ArtifactMeta{OS: "linux", Arch: "noarch", Stack: "any-stack"},
+			Fetcher:            f,
+		},
+		&PassthroughRecipe{
+			DepName:            "jacoco",
+			SourceFilenameFunc: func(v string) string { return fmt.Sprintf("jacoco-%s.zip", v) },
+			Meta:               ArtifactMeta{OS: "linux", Arch: "noarch", Stack: "any-stack"},
+			Fetcher:            f,
+		},
 		// PyPI sdist deps — download and strip top-level dir, no compilation.
 		&PyPISourceRecipe{DepName: "setuptools", Fetcher: f},
 		&PyPISourceRecipe{DepName: "flit-core", Fetcher: f},

--- a/internal/recipe/recipe_test.go
+++ b/internal/recipe/recipe_test.go
@@ -255,6 +255,10 @@ func TestPassthroughSourceFilenames(t *testing.T) {
 		{"sapmachine", "21.0.2", "sapmachine-jre-21.0.2_linux-x64_bin.tar.gz"},
 		{"jprofiler-profiler", "13.0.14", "jprofiler_linux_13_0_14.tar.gz"},
 		{"your-kit-profiler", "2023.11.462", "YourKit-JavaProfiler-2023.11.462.zip"},
+		{"elastic-apm-agent", "1.51.0", "elastic-apm-agent-1.51.0.jar"},
+		{"postgresql-jdbc", "42.7.3", "postgresql-42.7.3.jar"},
+		{"mariadb-jdbc", "3.3.3", "mariadb-java-client-3.3.3.jar"},
+		{"jacoco", "0.8.11", "jacoco-0.8.11.zip"},
 	}
 
 	recipeMap := make(map[string]recipe.Recipe)
@@ -297,7 +301,7 @@ func TestPassthroughArtifactMeta(t *testing.T) {
 		recipeMap[rec.Name()] = rec
 	}
 
-	anyStack := []string{"azure-application-insights", "splunk-otel-javaagent", "open-telemetry-javaagent", "java-cfenv", "tomcat", "composer", "appdynamics", "appdynamics-java", "skywalking-agent"}
+	anyStack := []string{"azure-application-insights", "splunk-otel-javaagent", "open-telemetry-javaagent", "java-cfenv", "tomcat", "composer", "appdynamics", "appdynamics-java", "skywalking-agent", "elastic-apm-agent", "postgresql-jdbc", "mariadb-jdbc", "jacoco"}
 	for _, name := range anyStack {
 		t.Run(name+"_any-stack", func(t *testing.T) {
 			rec := recipeMap[name]
@@ -331,6 +335,7 @@ func TestNewPassthroughRecipesContents(t *testing.T) {
 		"tomcat", "composer", "appdynamics", "appdynamics-java",
 		"skywalking-agent", "openjdk", "zulu", "sapmachine",
 		"jprofiler-profiler", "your-kit-profiler",
+		"elastic-apm-agent", "postgresql-jdbc", "mariadb-jdbc", "jacoco",
 		"setuptools", "flit-core",
 	})
 }


### PR DESCRIPTION
Update the passthrough recipes with regard to `elastic-apm-agent`, `postgresql-jdbc`,  `mariadb-jdbc` and `jacoco` buildpack dependencies.
Linked to https://github.com/cloudfoundry/buildpacks-ci/pull/632