### PR TITLE
Add flit-core as wheel to pip bundle

### DIFF
--- a/internal/recipe/pip.go
+++ b/internal/recipe/pip.go
@@ -48,6 +48,7 @@ func (p *PipRecipe) Build(ctx context.Context, s *stack.Stack, src *source.Input
 		ExtraDeps: []string{
 			"setuptools",
 			"wheel>=0.46.2", // CVE-2026-24049
+			"flit-core>=3.11", // build backend required by pip 26.x (downloaded as wheel to avoid circular dep)
 		},
 	}).Build(ctx, s, src, r, out)
 }


### PR DESCRIPTION
# Add flit-core as wheel to pip bundle (required by pip 26.x build backend)

## Problem
pip 26.x switched its build backend from setuptools to flit-core, requiring `flit-core>=3.11,<4` as a build dependency. When the Python buildpack installs pip from the bundle tarball using:

    pip install --no-index --find-links=/tmp/pip

pip tries to install its build dependencies from /tmp/pip, but the bundle only contained pip's own source tarball — not flit-core. This caused staging to fail with:

    ERROR: Could not find a version that satisfies the requirement flit-core<4,>=3.11 (from versions: none)
    ERROR: No matching distribution found for flit-core<4,>=3.11

## Fix

Add `flit-core>=3.11` to `ExtraDeps` in `PipRecipe`. `ExtraDeps` are downloaded without `--no-binary :all:`, so flit-core is fetched as a pre-built wheel (`flit_core-x.x.x-py3-none-any.whl`). This breaks the circular dependency (flit-core source requires flit-core to build) and makes it available in /tmp/pip for pip to use as its build backend.

## Testing

Rebuild the pip 26.x bundle using binary-builder and verify staging a Python app with `PIP_VERSION=latest` succeeds on cflinuxfs4/cflinuxfs5.

Fixes: https://github.com/cloudfoundry/python-buildpack/pull/1200