### PR TITLE
Fix pip build: pin flit-core<4 to match pip's build requirement

### DIFF
--- a/internal/recipe/pip.go
+++ b/internal/recipe/pip.go
@@ -47,8 +47,8 @@ func (p *PipRecipe) Build(ctx context.Context, s *stack.Stack, src *source.Input
 		},
 		ExtraDeps: []string{
 			"setuptools",
-			"wheel>=0.46.2", // CVE-2026-24049
-			"flit-core>=3.11", // build backend required by pip 26.x (downloaded as wheel to avoid circular dep)
+			"wheel>=0.46.2",      // CVE-2026-24049
+			"flit-core>=3.11,<4", // build backend required by pip 26.x (must be <4 per pip's pyproject.toml)
 		},
 	}).Build(ctx, s, src, r, out)
 }


### PR DESCRIPTION
## Summary

- Pin `flit-core>=3.11,<4` instead of just `flit-core>=3.11` in the pip recipe

## Problem

pip 26.x requires `flit-core>=3.11,<4` in its `pyproject.toml` build-system:

```toml
[build-system]
requires = ["flit-core >=3.11,<4"]
build-backend = "flit_core.buildapi"
```

The previous constraint `flit-core>=3.11` resolved to flit-core 4.0.2, which does **not** satisfy the `<4` upper bound. This causes pip installation to fail:

```
ERROR: Could not find a version that satisfies the requirement flit-core<4,>=3.11 (from versions: 4.0.2)
ERROR: No matching distribution found for flit-core<4,>=3.11
```

## Solution

Pin the upper bound to match pip's actual requirement: `flit-core>=3.11,<4`

## Testing

After this fix is merged and pip is rebuilt, the python-buildpack PR #1211 (pip 26.2.1 update) should pass its integration tests.

## Related

- python-buildpack PR #1211: https://github.com/cloudfoundry/python-buildpack/pull/1211