### PR TITLE
Add flit-core as wheel to pip bundle (required by pip 26.x build backend)

### DIFF
--- a/internal/recipe/pip.go
+++ b/internal/recipe/pip.go
@@ -48,6 +48,7 @@ func (p *PipRecipe) Build(ctx context.Context, s *stack.Stack, src *source.Input
 		ExtraDeps: []string{
 			"setuptools",
 			"wheel>=0.46.2", // CVE-2026-24049
+			"flit-core>=3.11,<4", // build backend required by pip 26.x; <4 matches pip's own build-requires constraint
 		},
 	}).Build(ctx, s, src, r, out)
 }


### PR DESCRIPTION
Add flit-core as wheel to pip bundle (required by pip 26.x build backend)
`"flit-core>=3.11,<4", // build backend required by pip 26.x; <4 matches pip's own build-requires constraint`